### PR TITLE
github: rebuild images only every 6 hours

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -4,7 +4,7 @@ name: Build docker images
 "on":
   workflow_dispatch:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */6 * * *"
   push:
     paths:
       - .github/workflows/build-docker-images.yml


### PR DESCRIPTION
We need to save some time on the Github Actions.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>