### PR TITLE
Revert "github: disable victoria builds"

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         openstack_version:
+          - victoria
           - wallaby
           - latest
     steps:


### PR DESCRIPTION
This reverts commit c8c0edcae3eee2f8b9a32935a186b1a478fcb03e.

With 6bcf3e96ab6b747d8783adc65462914fa0d80fce the regular builds
were changed from 2h to 6h. Therefore, it is now possible to
build 3 releases regularly.