### PR TITLE
Fix pip failures in victoria builds

### DIFF
--- a/patches/kolla-build/victoria/fix-pip-install-failures.patch
+++ b/patches/kolla-build/victoria/fix-pip-install-failures.patch
@@ -1,0 +1,12 @@
+diff --git a/docker/openstack-base/Dockerfile.j2 b/docker/openstack-base/Dockerfile.j2
+index a1120332e..f7cce1906 100644
+--- a/docker/openstack-base/Dockerfile.j2
++++ b/docker/openstack-base/Dockerfile.j2
+@@ -320,6 +320,7 @@ RUN ln -s openstack-base-source/* /requirements \
+     && virtualenv --system-site-packages /var/lib/kolla/venv
+ 
+ ENV PATH /var/lib/kolla/venv/bin:$PATH
++ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+ 
+ RUN {{ macros.install_pip(openstack_base_pip_packages | customizable("pip_packages")) }}
+ 


### PR DESCRIPTION
Tell setuptools to keep using the old behavior until packages have been
updated. See also [0].

[0] https://review.opendev.org/c/openstack/kolla/+/822679

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>