### PR TITLE
Disable fail fast for container builds

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -14,6 +14,7 @@ jobs:
   build-container-images:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         openstack_version:
           - victoria


### PR DESCRIPTION
We want to see all build results even if one of them fails.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>