### PR TITLE
github: remove victoria build

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         openstack_version:
-          - victoria
           - wallaby
           - xena
           - latest


### PR DESCRIPTION
Xena + Wallaby are active. Bye, Bye Victoria

Signed-off-by: Christian Berendt <berendt@osism.tech>