### PR TITLE
Remove base sources

### DIFF
--- a/templates/latest/template-overrides.mako
+++ b/templates/latest/template-overrides.mako
@@ -79,7 +79,8 @@ RUN apt-get update ${"\\"}
 
 {% block footer %}
 RUN rm -rf /usr/share/doc/* ${"\\"}
-    && rm -rf /usr/share/man/*
+    && rm -rf /usr/share/man/* ${"\\"}
+    && rm -rf /*-base-source
 {% endblock %}
 
 {% block labels %}

--- a/templates/xena/template-overrides.mako
+++ b/templates/xena/template-overrides.mako
@@ -79,7 +79,8 @@ RUN apt-get update ${"\\"}
 
 {% block footer %}
 RUN rm -rf /usr/share/doc/* ${"\\"}
-    && rm -rf /usr/share/man/*
+    && rm -rf /usr/share/man/* ${"\\"}
+    && rm -rf /*-base-source
 {% endblock %}
 
 {% block labels %}


### PR DESCRIPTION
This removes the source directories from the images. These are no longer
needed when items are installed.

24K	./nova-base-source/nova-24.0.1.dev30/releasenotes/source/locale/ko_KR/LC_MESSAGES
28K	./nova-base-source/nova-24.0.1.dev30/releasenotes/source/locale/ko_KR
16K	./nova-base-source/nova-24.0.1.dev30/releasenotes/source/locale/en_GB/LC_MESSAGES
20K	./nova-base-source/nova-24.0.1.dev30/releasenotes/source/locale/en_GB

Signed-off-by: Christian Berendt <berendt@osism.tech>