### PR TITLE
Remove build-essential package

### DIFF
--- a/templates/xena/template-overrides.mako
+++ b/templates/xena/template-overrides.mako
@@ -81,6 +81,9 @@ RUN apt-get update ${"\\"}
 RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && rm -rf /*-base-source
+
+RUN apt-get remove -y build-essential git ${"\\"}
+    && apt-get autoremove -y
 {% endblock %}
 
 {% block labels %}

--- a/templates/xena/template-overrides.mako
+++ b/templates/xena/template-overrides.mako
@@ -82,7 +82,7 @@ RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && rm -rf /*-base-source
 
-RUN apt-get remove -y build-essential git ${"\\"}
+RUN apt-get remove -y build-essential ${"\\"}
     && apt-get autoremove -y
 {% endblock %}
 


### PR DESCRIPTION
The packages are no longer needed after building the images
and only occupy space unnecessarily.

Closes #153

Signed-off-by: Christian Berendt <berendt@osism.tech>