### PR TITLE
Add auto-renovate for the requirements.txt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "github>osism/renovate-config"
   ],
-  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>"
+  "pip_requierements": {
+    "fileMatch": ["requirements.txt"]
+  }
 }


### PR DESCRIPTION
- Add auto-renovate for the requirements.txt to auto-update the versions.
- This is partly osism/issue#155

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
