### PR TITLE
xena: always use versions instead of the stable branche

### DIFF
--- a/templates/xena/kolla-build.conf.j2
+++ b/templates/xena/kolla-build.conf.j2
@@ -21,13 +21,8 @@ threads = 4
 [{{ project.name }}]
 {% endif -%}
 type = local
-{% is_release == "false" %}
-# tarball = https://tarballs.opendev.org/openstack/{{ project.repository }}/{{ project.repository }}-stable-{{ openstack_release }}.tar.gz
-location = tarballs/{{ project.repository }}-stable-{{ openstack_release }}.tar.gz
-{% else %}
 # tarball = https://tarballs.opendev.org/openstack/{{ project.repository }}/{{ project.repository }}-{{ project.version }}.tar.gz
 location = tarballs/{{ project.repository }}-{{ project.version }}.tar.gz
-{% endif %}
 {%- endfor %}
 
 # projects with a specific version (!= openstack_release)


### PR DESCRIPTION
Reproducibility makes it necessary to use static versions
instead of the stable branch. Also in latest in preparations
for a release.

Signed-off-by: Christian Berendt <berendt@osism.tech>