### PR TITLE
yoga: install python-linstor in cinder-volume

### DIFF
--- a/templates/yoga/template-overrides.mako
+++ b/templates/yoga/template-overrides.mako
@@ -35,7 +35,7 @@ RUN apt-get update ${"\\"}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}
 
-{% set cinder_volume_pip_packages = [ 'cinderlib', 'purestorage', 'infinisdk' ] %}
+{% set cinder_volume_pip_packages = [ 'cinderlib', 'purestorage', 'infinisdk', 'python-linstor' ] %}
 {% block cinder_volume_footer %}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}


### PR DESCRIPTION
This way linstor can be used as storage backend.

Signed-off-by: Christian Berendt <berendt@osism.tech>