### PR TITLE
Pin erlang and rmq for xena and yoga

### DIFF
--- a/templates/xena/apt_preferences.ubuntu.j2
+++ b/templates/xena/apt_preferences.ubuntu.j2
@@ -1,0 +1,7 @@
+Package: rabbitmq-server
+Pin: version 3.10.*
+Pin-Priority: 1000
+
+Package: erlang*
+Pin: version 1:25.*
+Pin-Priority: 1000

--- a/templates/yoga/apt_preferences.ubuntu.j2
+++ b/templates/yoga/apt_preferences.ubuntu.j2
@@ -1,0 +1,7 @@
+Package: rabbitmq-server
+Pin: version 3.10.*
+Pin-Priority: 1000
+
+Package: erlang*
+Pin: version 1:25.*
+Pin-Priority: 1000


### PR DESCRIPTION
The rabbitmq repo now contains rabbitmq 3.11.0, which doesn't seem stable yet, pin to 3.10.* for now, copying what kolla upstream does. Pin erlang to a compatible version.

Closes: osism/issues#328
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>