### PR TITLE
Fix key error in src/tag-images-with-the-version.py

### DIFF
--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -189,6 +189,7 @@ SBOM_IMAGE_TO_VERSION = {
     "keystone": "keystone",
     "kibana": "kibana",
     "kolla_toolbox": "kolla-toolbox",
+    "kolla-toolbox": "kolla-toolbox",
     "kuryr": "kuryr-libnetwork",
     "logstash": "logstash",
     "magnum": "magnum-api",
@@ -232,7 +233,10 @@ for image in flat_list_of_images:
     sbom_versions[name] = version
 
 for name in SBOM_IMAGE_TO_VERSION:
-    sbom["versions"][name] = sbom_versions[SBOM_IMAGE_TO_VERSION[name]]
+    try:
+        sbom["versions"][name] = sbom_versions[SBOM_IMAGE_TO_VERSION[name]]
+    except KeyError:
+        pass
 
 with open("images.yml", "w+") as fp:
     dump(sbom, fp, default_flow_style=False, explicit_start=True)


### PR DESCRIPTION
2022-11-08T07:33:08.7822813Z Traceback (most recent call last):
2022-11-08T07:33:08.7948172Z   File "/home/runner/work/container-images-***/container-images-***/src/tag-images-with-the-version.py", line 235, in <module>
2022-11-08T07:33:08.7948825Z     sbom["versions"][name] = sbom_versions[SBOM_IMAGE_TO_VERSION[name]]
2022-11-08T07:33:08.7949562Z                              ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2022-11-08T07:33:08.7950052Z KeyError: '***-toolbox'

Signed-off-by: Christian Berendt <berendt@osism.tech>