### PR TITLE
github: rebuild images once a day

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -4,7 +4,7 @@ name: Build container images
 "on":
   workflow_dispatch:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 0 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
It is sufficient if the images are rebuilt once a day.

Signed-off-by: Christian Berendt <berendt@osism.tech>