### PR TITLE
zed: remove neutron-mlnx-agent image

### DIFF
--- a/patches/zed/kolla/remove-neutron-mlnx-agent.patch
+++ b/patches/zed/kolla/remove-neutron-mlnx-agent.patch
@@ -1,0 +1,31 @@
+--- a/docker/neutron/neutron-mlnx-agent/Dockerfile.j2
++++ /dev/null
+@@ -1,28 +0,0 @@
+-FROM {{ namespace }}/{{ image_prefix }}neutron-base:{{ tag }}
+-{% block labels %}
+-LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+-{% endblock %}
+-
+-{% block neutron_mlnx_agent_header %}{% endblock %}
+-
+-{% import "macros.j2" as macros with context %}
+-
+-{{ macros.enable_extra_repos(['libvirt']) }}
+-
+-{% set neutron_mlnx_agent_packages = [
+-    'python3-libvirt',
+-    'python3-ethtool',
+-] %}
+-
+-{{ macros.install_packages(neutron_mlnx_agent_packages | customizable("packages")) }}
+-
+-{% set neutron_mlnx_agent_pip_packages = [
+-    'networking-mlnx'
+-] %}
+-
+-RUN {{ macros.install_pip(neutron_mlnx_agent_pip_packages | customizable("pip_packages")) }}
+-
+-{% block neutron_mlnx_agent_footer %}{% endblock %}
+-{% block footer %}{% endblock %}
+-
+-USER neutron


### PR DESCRIPTION
The build is failing and we are not using this image anywhere at the moment.

Signed-off-by: Christian Berendt <berendt@osism.tech>