### PR TITLE
zed: install pywinrm in manila packages

### DIFF
--- a/templates/zed/template-overrides.mako
+++ b/templates/zed/template-overrides.mako
@@ -40,6 +40,11 @@ RUN apt-get update ${"\\"}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}
 
+{% set manila_base_additional_pip_packages = [ 'pywinrm' ] %}
+{% block manila_base_footer %}
+RUN {{ macros.install_pip(manila_base_additional_pip_packages | customizable("pip_packages")) }}
+{% endblock %}
+
 {% set gnocchi_base_packages_append = ['python3-rados'] %}
 
 {% block grafana_footer %}


### PR DESCRIPTION
Required to be able to use the windows_smb backend.

Closes osism/issues#363

Signed-off-by: Christian Berendt <berendt@osism.tech>