### PR TITLE
zed: install magnum-cluster-api in magnum base image

### DIFF
--- a/templates/zed/template-overrides.mako
+++ b/templates/zed/template-overrides.mako
@@ -45,6 +45,11 @@ RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_package
 RUN {{ macros.install_pip(manila_base_additional_pip_packages | customizable("pip_packages")) }}
 {% endblock %}
 
+{% set magnum_base_additional_pip_packages = [ 'magnum-cluster-api' ] %}
+{% block magnum_base_footer %}
+RUN {{ macros.install_pip(magnum_base_additional_pip_packages | customizable("pip_packages")) }}
+{% endblock %}
+
 {% set gnocchi_base_packages_append = ['python3-rados'] %}
 
 {% block grafana_footer %}


### PR DESCRIPTION
Required to be able to use cluster api with magnum.

https://pypi.org/project/magnum-cluster-api

Signed-off-by: Christian Berendt <berendt@osism.tech>