### PR TITLE
zed: use rabbitmq 3.11

### DIFF
--- a/templates/zed/apt_preferences.ubuntu.j2
+++ b/templates/zed/apt_preferences.ubuntu.j2
@@ -1,5 +1,5 @@
 Package: rabbitmq-server
-Pin: version 3.10.*
+Pin: version 3.11.*
 Pin-Priority: 1000
 
 Package: erlang*


### PR DESCRIPTION
End of Community Support for 3.10: 31 July, 2023