### PR TITLE
yoga: add pin-ansible-posix-in-kolla-toolbox.patch

### DIFF
--- a/patches/yoga/kolla/pin-ansible-posix-in-kolla-toolbox.patch
+++ b/patches/yoga/kolla/pin-ansible-posix-in-kolla-toolbox.patch
@@ -1,0 +1,11 @@
+--- a/docker/kolla-toolbox/requirements.yml
++++ b/docker/kolla-toolbox/requirements.yml
+@@ -1,7 +1,7 @@
+ ---
+ collections:
+   - name: ansible.posix
+-    version: '<2'
++    version: '1.5.2'
+   - name: community.general
+     version: '<4'
+   - name: community.mysql


### PR DESCRIPTION
Pin ansible.posix version to 1.5.2

versions > 1.5.2 currently triggers race conditions in various stable/yoga roles (ovn, openvswitch)