### PR TITLE
Fix erlang and rabbitmq debs

### DIFF
--- a/overlays/2023.1/base/erlang.list
+++ b/overlays/2023.1/base/erlang.list
@@ -1,0 +1,1 @@
+deb [signed-by=/etc/apt/keyrings/erlang_solutions.asc] https://packages.erlang-solutions.com/ubuntu focal contrib

--- a/overlays/2023.1/base/rabbitmq.list
+++ b/overlays/2023.1/base/rabbitmq.list
@@ -1,0 +1,2 @@
+deb [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main
+deb-src [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main

--- a/overlays/yoga/base/erlang.list
+++ b/overlays/yoga/base/erlang.list
@@ -1,0 +1,1 @@
+deb [signed-by=/etc/apt/keyrings/erlang_solutions.asc] https://packages.erlang-solutions.com/ubuntu focal contrib

--- a/overlays/yoga/base/rabbitmq.list
+++ b/overlays/yoga/base/rabbitmq.list
@@ -1,0 +1,2 @@
+deb [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main
+deb-src [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main

--- a/overlays/zed/base/erlang.list
+++ b/overlays/zed/base/erlang.list
@@ -1,0 +1,1 @@
+deb [signed-by=/etc/apt/keyrings/erlang_solutions.asc] https://packages.erlang-solutions.com/ubuntu focal contrib

--- a/overlays/zed/base/rabbitmq.list
+++ b/overlays/zed/base/rabbitmq.list
@@ -1,0 +1,2 @@
+deb [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main
+deb-src [signed-by=/etc/apt/keyrings/rabbitmq.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu jammy main

--- a/templates/2023.1/template-overrides.mako
+++ b/templates/2023.1/template-overrides.mako
@@ -14,13 +14,20 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block base_header %}
+RUN apt-get update ${"\\"}
+    && apt-get -y install --no-install-recommends locales ca-certificates curl gnupg2 ${"\\"}
+    && locale-gen en_US.UTF-8 ${"\\"}
+    && apt-get clean ${"\\"}
+    && rm -rf /var/lib/apt/lists/*
 COPY apt_preferences.{{ base_distro }} /etc/apt/preferences
+COPY erlang.list /etc/apt/sources.list.d/erlang.list
+COPY rabbitmq.list /etc/apt/sources.list.d/rabbitmq.list
 COPY osism.list /etc/apt/sources.list.d/osism.list
 COPY osism-archive-keyring.gpg /etc/apt/keyrings/osism-archive-keyring.gpg
 
-RUN apt-get update ${"\\"}
-    && apt-get -y install --no-install-recommends locales ca-certificates ${"\\"}
-    && locale-gen en_US.UTF-8 ${"\\"}
+RUN curl -sLfo /etc/apt/keyrings/erlang_solutions.asc https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc ${"\\"}
+    && curl -sLf https://ppa1.novemberain.com/gpg.9F4587F226208342.key | gpg --dearmor > /etc/apt/keyrings/rabbitmq.gpg ${"\\"}
+    && apt-get update ${"\\"}
     && apt-get clean ${"\\"}
     && rm -rf /var/lib/apt/lists/*
 {% endblock %}

--- a/templates/yoga/template-overrides.mako
+++ b/templates/yoga/template-overrides.mako
@@ -14,12 +14,21 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block base_header %}
-COPY apt_preferences.{{ base_distro }} /etc/apt/preferences
 RUN apt-get update ${"\\"}
-    && apt-get -y install --no-install-recommends locales ${"\\"}
+    && apt-get -y install --no-install-recommends locales ca-certificates curl gnupg2 ${"\\"}
+    && locale-gen en_US.UTF-8 ${"\\"}
+    && apt-get clean ${"\\"}
+    && rm -rf /var/lib/apt/lists/*
+COPY apt_preferences.{{ base_distro }} /etc/apt/preferences
+COPY erlang.list /etc/apt/sources.list.d/erlang.list
+COPY rabbitmq.list /etc/apt/sources.list.d/rabbitmq.list
+
+RUN mkdir /etc/apt/keyrings ${"\\"}
+    && curl -sLfo /etc/apt/keyrings/erlang_solutions.asc https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc ${"\\"}
+    && curl -sLf https://ppa1.novemberain.com/gpg.9F4587F226208342.key | gpg --dearmor > /etc/apt/keyrings/rabbitmq.gpg ${"\\"}
+    && apt-get update ${"\\"}
     && apt-get clean ${"\\"}
     && rm -rf /var/lib/apt/lists/* ${"\\"}
-    && locale-gen en_US.UTF-8
 {% endblock %}
 
 {% block openstack_base_header %}

--- a/templates/zed/template-overrides.mako
+++ b/templates/zed/template-overrides.mako
@@ -14,13 +14,20 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block base_header %}
+RUN apt-get update ${"\\"}
+    && apt-get -y install --no-install-recommends locales ca-certificates curl gnupg2 ${"\\"}
+    && locale-gen en_US.UTF-8 ${"\\"}
+    && apt-get clean ${"\\"}
+    && rm -rf /var/lib/apt/lists/*
 COPY apt_preferences.{{ base_distro }} /etc/apt/preferences
+COPY erlang.list /etc/apt/sources.list.d/erlang.list
+COPY rabbitmq.list /etc/apt/sources.list.d/rabbitmq.list
 COPY osism.list /etc/apt/sources.list.d/osism.list
 COPY osism-archive-keyring.gpg /etc/apt/keyrings/osism-archive-keyring.gpg
 
-RUN apt-get update ${"\\"}
-    && apt-get -y install --no-install-recommends locales ca-certificates ${"\\"}
-    && locale-gen en_US.UTF-8 ${"\\"}
+RUN curl -sLfo /etc/apt/keyrings/erlang_solutions.asc https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc ${"\\"}
+    && curl -sLf https://ppa1.novemberain.com/gpg.9F4587F226208342.key | gpg --dearmor > /etc/apt/keyrings/rabbitmq.gpg ${"\\"}
+    && apt-get update ${"\\"}
     && apt-get clean ${"\\"}
     && rm -rf /var/lib/apt/lists/*
 {% endblock %}


### PR DESCRIPTION
In ubuntu 22.04 only older versions of rabbitmq and erlang are available.
This patch adds the debs for the newer versions.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
