### PR TITLE
Mark gnocchi as unbuildable for Z+A

### DIFF
--- a/patches/kolla-build/2023.1/gnocchi-unbuildable.patch
+++ b/patches/kolla-build/2023.1/gnocchi-unbuildable.patch
@@ -1,0 +1,70 @@
+commit 5505cd000ce7f12c272c5b62074c9cc6bf1bb7a7
+Author: Maksim Malchuk <maksim.malchuk@gmail.com>
+Date:   Tue Jun 20 13:06:48 2023 +0300
+
+    Disable build of Gnocchi containers
+    
+    Revert this commit when [1] is solved.
+    
+    1. https://github.com/gnocchixyz/gnocchi/issues/1304
+    
+    Change-Id: Iafeb9093340621d65a9c9cd126d65679d981dfb1
+    Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
+
+diff --git a/kolla/image/unbuildable.py b/kolla/image/unbuildable.py
+index dc5183162..9ead6ef52 100644
+--- a/kolla/image/unbuildable.py
++++ b/kolla/image/unbuildable.py
+@@ -16,14 +16,16 @@
+ # must match for skip to happen.
+ UNBUILDABLE_IMAGES = {
+     'aarch64': {
+-        "bifrost-base",      # someone need to get upstream working first
++        "gnocchi-base",        # https://github.com/gnocchixyz/gnocchi/issues/1304 # noqa
++        "bifrost-base",        # someone need to get upstream working first
+         "prometheus-msteams",  # no aarch64 binary
+-        "prometheus-mtail",  # no aarch64 binary
++        "prometheus-mtail",    # no aarch64 binary
+     },
+ 
+     # Issues for SHA1 keys:
+     # https://github.com/grafana/grafana/issues/41036
+     'centos': {
++        "gnocchi-base",          # https://github.com/gnocchixyz/gnocchi/issues/1304 # noqa
+         "hacluster-pcs",         # Missing crmsh package
+         "nova-spicehtml5proxy",  # Missing spicehtml5 package
+         "ovsdpdk",               # Not supported on CentOS
+@@ -31,9 +33,11 @@ UNBUILDABLE_IMAGES = {
+     },
+ 
+     'debian': {
++        "gnocchi-base",  # https://github.com/gnocchixyz/gnocchi/issues/1304
+     },
+ 
+     'rocky': {
++        "gnocchi-base",          # https://github.com/gnocchixyz/gnocchi/issues/1304 # noqa
+         "hacluster-pcs",         # Missing crmsh package
+         "nova-spicehtml5proxy",  # Missing spicehtml5 package
+         "ovsdpdk",               # Not supported on CentOS
+@@ -41,15 +45,18 @@ UNBUILDABLE_IMAGES = {
+     },
+ 
+     'ubuntu': {
+-        "collectd",              # Missing collectd-core package
+-        "telegraf",              # Missing collectd-core package
++        "gnocchi-base",  # https://github.com/gnocchixyz/gnocchi/issues/1304
++        "collectd",      # Missing collectd-core package
++        "telegraf",      # Missing collectd-core package
+     },
+ 
+     'ubuntu+aarch64': {
++        "gnocchi-base",   # https://github.com/gnocchixyz/gnocchi/issues/1304
+         "barbican-base",  # https://github.com/unbit/uwsgi/issues/2434
+     },
+ 
+     'centos+aarch64': {
+-        "telegraf",       # no binary package
++        "gnocchi-base",  # https://github.com/gnocchixyz/gnocchi/issues/1304
++        "telegraf",      # no binary package
+     },
+ }

--- a/patches/kolla-build/zed/gnocchi-unbuildable.patch
+++ b/patches/kolla-build/zed/gnocchi-unbuildable.patch
@@ -1,0 +1,33 @@
+commit 5505cd000ce7f12c272c5b62074c9cc6bf1bb7a7
+Author: Maksim Malchuk <maksim.malchuk@gmail.com>
+Date:   Tue Jun 20 13:06:48 2023 +0300
+
+    Disable build of Gnocchi containers
+    
+    Revert this commit when [1] is solved.
+    
+    1. https://github.com/gnocchixyz/gnocchi/issues/1304
+    
+    Fixed merged conflict for cherry-pick, only marked ubuntu.
+
+    Change-Id: Iafeb9093340621d65a9c9cd126d65679d981dfb1
+    Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
+
+diff --git a/kolla/image/unbuildable.py b/kolla/image/unbuildable.py
+index c945fcf1b..e91493dc3 100644
+--- a/kolla/image/unbuildable.py
++++ b/kolla/image/unbuildable.py
+@@ -42,9 +42,10 @@ UNBUILDABLE_IMAGES = {
+     },
+ 
+     'ubuntu': {
+-        "bifrost-base",          # Failing on new efi shim file location
+-        "collectd",              # Missing collectd-core package
+-        "telegraf",              # Missing collectd-core package
++        "bifrost-base",   # Failing on new efi shim file location
++        "collectd",       # Missing collectd-core package
++        "gnocchi-base",   # https://github.com/gnocchixyz/gnocchi/issues/1304
++        "telegraf",       # Missing collectd-core package
+     },
+ 
+     'ubuntu+aarch64': {


### PR DESCRIPTION
See https://github.com/gnocchixyz/gnocchi/issues/1304