### PR TITLE
zuul: fix push play (pt. 1)

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -9,6 +9,7 @@
         username: "{{ secret.DOCKER_USERNAME }}"
         password: "{{ secret.DOCKER_PASSWORD }}"
       when: push_images | bool
+      no_log: true
 
     - name: Run build script
       ansible.builtin.shell:
@@ -44,8 +45,3 @@
           bash scripts/100-push.sh
       changed_when: false
       when: push_images | bool
-      no_log: true
-      environment:
-        DOCKER_NAMESPACE: "{{ docker_namespace }}"
-        DOCKER_REGISTRY: "{{ docker_registry }}"
-        OPENSTACK_VERSION: "{{ version_openstack }}"


### PR DESCRIPTION
It's fine to see the logs of the 100-push.sh script.

Also remove unused environment variables & hide logs of the docker login task.