### PR TITLE
Add missing path to access add-image-checksum.py

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -136,7 +136,6 @@
     name: container-images-kolla-release
     parent: container-images-kolla-build
     vars:
-      docker_namespace: kolla/release
       is_release: true
       push_images: true
     secrets:

--- a/scripts/005-tag.sh
+++ b/scripts/005-tag.sh
@@ -78,7 +78,7 @@ docker images
 if [[ $IS_RELEASE == "True" ]]; then
     mkdir -p $VERSION
     cp images.yml $VERSION/openstack.yml
-    python3 add-image-checksum.py
+    python3 src/add-image-checksum.py
     cat $VERSION/openstack.yml
 fi
 


### PR DESCRIPTION
Also do not set docker_namespace in the release job, this is already part of a script and redundant.