### PR TITLE
Use label pipeline for deployment jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -161,6 +161,8 @@
       jobs:
         - flake8
         - yamllint
+    label:
+      jobs:
         - container-images-kolla-build-zed
         - container-images-kolla-build-antelope
     gate:


### PR DESCRIPTION
We want to run these jobs only after a core reviewer has looked at the PR and attached the "zuul" label.