### PR TITLE
2023.2: bring back the magnum-cluster-api plugin

### DIFF
--- a/templates/2023.2/template-overrides.mako
+++ b/templates/2023.2/template-overrides.mako
@@ -53,7 +53,9 @@ RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_package
 RUN {{ macros.install_pip(manila_base_additional_pip_packages | customizable("pip_packages")) }}
 {% endblock %}
 
+{% set magnum_base_additional_pip_packages = [ 'magnum-cluster-api' ] %}
 {% block magnum_base_footer %}
+RUN {{ macros.install_pip(magnum_base_additional_pip_packages | customizable("pip_packages")) }}
 RUN git clone https://github.com/stackhpc/magnum-capi-helm.git /magnum-capi-helm ${"\\"}
     && pip install -e /magnum-capi-helm
 RUN curl -o /tmp/helm.tar.gz https://get.helm.sh/helm-v3.14.1-linux-amd64.tar.gz ${"\\"}


### PR DESCRIPTION
Related to osism/issues#867