### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/magnum-helm-a17cbe5407ec41b8.yaml
+++ b/releasenotes/notes/magnum-helm-a17cbe5407ec41b8.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Helm is required by the Magnum Cluster API plugin and is now installed in all Magnum container images.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.