### PR TITLE
Use org.opencontainers.image.version label for service versions

### DIFF
--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -199,12 +199,12 @@ for image in client.images.list(filters=FILTERS):
                     target_tag = target_tag.replace("/kolla/", "/kolla/release/")
 
                 logger.info(
-                    f"Adding de.osism.service.version='{target_version}' label to {tag}"
+                    f"Adding org.opencontainers.image.version='{target_version}' label to {tag}"
                 )
                 with tempfile.NamedTemporaryFile() as fp:
                     fp.write(f"FROM {tag}\n".encode())
                     fp.write(
-                        f"LABEL de.osism.service.version='{target_version}'\n".encode()
+                        f"LABEL org.opencontainers.image.version='{target_version}'\n".encode()
                     )
                     fp.seek(0)
 

--- a/templates/2023.1/template-overrides.mako
+++ b/templates/2023.1/template-overrides.mako
@@ -110,6 +110,5 @@ LABEL "build-date"="{{ build_date }}" ${"\\"}
       "org.opencontainers.image.source"="https://github.com/osism/container-images-kolla" ${"\\"}
       "org.opencontainers.image.title"="{{ image_name }}" ${"\\"}
       "org.opencontainers.image.url"="https://quay.io/organization/osism" ${"\\"}
-      "org.opencontainers.image.vendor"="OSISM GmbH" ${"\\"}
-      "org.opencontainers.image.version"="${version}"
+      "org.opencontainers.image.vendor"="OSISM GmbH"
 {% endblock %}

--- a/templates/2023.2/template-overrides.mako
+++ b/templates/2023.2/template-overrides.mako
@@ -124,6 +124,5 @@ LABEL "build-date"="{{ build_date }}" ${"\\"}
       "org.opencontainers.image.source"="https://github.com/osism/container-images-kolla" ${"\\"}
       "org.opencontainers.image.title"="{{ image_name }}" ${"\\"}
       "org.opencontainers.image.url"="https://quay.io/organization/osism" ${"\\"}
-      "org.opencontainers.image.vendor"="OSISM GmbH" ${"\\"}
-      "org.opencontainers.image.version"="${version}"
+      "org.opencontainers.image.vendor"="OSISM GmbH"
 {% endblock %}

--- a/templates/2024.1/template-overrides.mako
+++ b/templates/2024.1/template-overrides.mako
@@ -124,6 +124,5 @@ LABEL "build-date"="{{ build_date }}" ${"\\"}
       "org.opencontainers.image.source"="https://github.com/osism/container-images-kolla" ${"\\"}
       "org.opencontainers.image.title"="{{ image_name }}" ${"\\"}
       "org.opencontainers.image.url"="https://quay.io/organization/osism" ${"\\"}
-      "org.opencontainers.image.vendor"="OSISM GmbH" ${"\\"}
-      "org.opencontainers.image.version"="${version}"
+      "org.opencontainers.image.vendor"="OSISM GmbH"
 {% endblock %}


### PR DESCRIPTION
Remove the custom de.osism.service.version label in favor of the org.opencontainers.image.version label.

The org.opencontainers.image.version is now used for the version of the service in the container image.