### PR TITLE
magnum: add backport of "add cilium in the supported network driver l…

### DIFF
--- a/patches/2023.2/magnum/magnum-cilium.patch
+++ b/patches/2023.2/magnum/magnum-cilium.patch
@@ -1,0 +1,32 @@
+--- a/magnum/api/validation.py
++++ b/magnum/api/validation.py
+@@ -321,7 +321,12 @@ class Validator(object):
+
+ class K8sValidator(Validator):
+
+-    supported_network_drivers = ['flannel', 'calico']
++    # NOTE(okozachenko): Cilium is added in the supported list because some
++    # cluster drivers like capi-driver supports this. But the Heat driver
++    # doesn't support this yet.
++    # In the future, supported network driver list should be fetched from
++    # cluster driver implementation instead of this fixed values.
++    supported_network_drivers = ['flannel', 'calico', 'cilium']
+     supported_server_types = ['vm', 'bm']
+     allowed_network_drivers = (
+         CONF.cluster_template.kubernetes_allowed_network_drivers)
+--- a/magnum/conf/cluster_templates.py
++++ b/magnum/conf/cluster_templates.py
+@@ -19,11 +19,8 @@ cluster_template_group = cfg.OptGroup(name='cluster_template',
+
+ cluster_template_opts = [
+     cfg.ListOpt('kubernetes_allowed_network_drivers',
+-                default=['all'],
+-                help=_("Allowed network drivers for kubernetes "
+-                       "cluster-templates. Use 'all' keyword to allow all "
+-                       "drivers supported for kubernetes cluster-templates. "
+-                       "Supported network drivers include flannel."),
++                default=['flannel', 'calico'],
++                help=_("Allowed network drivers for kubernetes."),
+                 ),
+     cfg.StrOpt('kubernetes_default_network_driver',
+                default='flannel',


### PR DESCRIPTION
…ist of k8s"

https://review.opendev.org/c/openstack/magnum/+/905427

Related to osism/k8s-capi-images#251