### PR TITLE
Ignore all Python deprecation warnings

### DIFF
--- a/templates/2023.2/template-overrides.mako
+++ b/templates/2023.2/template-overrides.mako
@@ -38,6 +38,7 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block openstack_base_header %}
+ENV PYTHONWARNINGS="ignore::DeprecationWarning"
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends python3-setuptools ${"\\"}
     && apt-get clean ${"\\"}

--- a/templates/2024.1/template-overrides.mako
+++ b/templates/2024.1/template-overrides.mako
@@ -38,6 +38,7 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block openstack_base_header %}
+ENV PYTHONWARNINGS="ignore::DeprecationWarning"
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends python3-setuptools ${"\\"}
     && apt-get clean ${"\\"}


### PR DESCRIPTION
The osism/container-images-kolla repository is not intended for the build OpenStack development images. Devstack should be used for OpenStack development. Therefore we are not interested in specific DeprecationWarnings.

Related to osism/issues#641