### PR TITLE
Do not install cinderlib

### DIFF
--- a/templates/2023.1/template-overrides.mako
+++ b/templates/2023.1/template-overrides.mako
@@ -43,7 +43,7 @@ RUN apt-get update ${"\\"}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}
 
-{% set cinder_volume_pip_packages = [ 'cinderlib', 'purestorage', 'infinisdk', 'python-linstor' ] %}
+{% set cinder_volume_pip_packages = [ 'purestorage', 'infinisdk', 'python-linstor' ] %}
 {% block cinder_volume_footer %}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}

--- a/templates/2023.2/template-overrides.mako
+++ b/templates/2023.2/template-overrides.mako
@@ -50,7 +50,7 @@ RUN apt-get update ${"\\"}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}
 
-{% set cinder_volume_pip_packages = [ 'cinderlib', 'purestorage', 'infinisdk', 'python-linstor' ] %}
+{% set cinder_volume_pip_packages = [ 'purestorage', 'infinisdk', 'python-linstor' ] %}
 {% block cinder_volume_footer %}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}

--- a/templates/2024.1/template-overrides.mako
+++ b/templates/2024.1/template-overrides.mako
@@ -50,7 +50,7 @@ RUN apt-get update ${"\\"}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}
 
-{% set cinder_volume_pip_packages = [ 'cinderlib', 'purestorage', 'infinisdk', 'python-linstor' ] %}
+{% set cinder_volume_pip_packages = [ 'purestorage', 'infinisdk', 'python-linstor' ] %}
 {% block cinder_volume_footer %}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}


### PR DESCRIPTION
This packages is not required and results in a wrong Cinder version for Cinder >= 24.0.0.