### PR TITLE
2024.1: install systemd-python package

### DIFF
--- a/templates/2024.1/template-overrides.mako
+++ b/templates/2024.1/template-overrides.mako
@@ -7,7 +7,7 @@
     'fluent-plugin-grafana-loki',
 ] %}
 
-{% set openstack_base_pip_packages_append = ['pip', 'git+https://github.com/sapcc/openstack-audit-middleware.git'] %}
+{% set openstack_base_pip_packages_append = ['pip', 'git+https://github.com/sapcc/openstack-audit-middleware.git', 'systemd-python' ] %}
 
 {% set glance_base_pip_packages_append = ['boto3'] %}
 


### PR DESCRIPTION
Required to be able to use the systemd journal support of the oslo.log library.

Part of osism/issues#1159