### PR TITLE
2025.1: use uv instead of pip

### DIFF
--- a/patches/2025.1/kolla/uv.patch
+++ b/patches/2025.1/kolla/uv.patch
@@ -1,0 +1,11 @@
+--- a/docker/macros.j2
++++ b/docker/macros.j2
+@@ -34,7 +34,7 @@
+
+ {% macro install_pip(packages, constraints=true, python_version='3') %}
+ {%- if packages is sequence and packages|length > 0 -%}
+-    python{{ python_version }} -m pip --no-cache-dir install --upgrade{{ ' ' }}
++    uv pip install --no-cache --upgrade{{ ' ' }}
+     {%- if constraints %}-c /requirements/upper-constraints.txt {% endif -%}
+     {{ packages | join(' ') }}
+ {%- else -%}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -46,7 +46,12 @@ RUN apt-get update ${"\\"}
     && rm -rf /var/lib/apt/lists/*
 {% endblock %}
 
+{% block kolla_toolbox_header %}
+COPY --from=ghcr.io/astral-sh/uv:0.8.22 /uv /usr/local/bin/uv
+{% endblock %}
+
 {% block openstack_base_header %}
+COPY --from=ghcr.io/astral-sh/uv:0.8.22 /uv /usr/local/bin/uv
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends python3-setuptools ${"\\"}
     && apt-get clean ${"\\"}


### PR DESCRIPTION
Installations with uv are a lot faster than with pip.