### PR TITLE
zuul: disable broken aarch64 builds

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -247,9 +247,9 @@
       jobs:
         - container-images-kolla-build-bobcat
         - container-images-kolla-build-caracal
-        - container-images-kolla-build-caracal-aarch64
         - container-images-kolla-build-dalmatian
-        - container-images-kolla-build-dalmatian-aarch64
+        # - container-images-kolla-build-caracal-aarch64
+        # - container-images-kolla-build-dalmatian-aarch64
     gate:
       jobs:
         - flake8
@@ -264,21 +264,21 @@
       jobs:
         - container-images-kolla-push-bobcat
         - container-images-kolla-push-caracal
-        - container-images-kolla-push-caracal-aarch64
         - container-images-kolla-push-dalmatian
-        - container-images-kolla-push-dalmatian-aarch64
+        # - container-images-kolla-push-caracal-aarch64
+        # - container-images-kolla-push-dalmatian-aarch64
     post:
       jobs:
         - container-images-kolla-push-bobcat:
             branches: main
         - container-images-kolla-push-caracal:
             branches: main
-        - container-images-kolla-push-caracal-aarch64:
-            branches: main
         - container-images-kolla-push-dalmatian:
             branches: main
-        - container-images-kolla-push-dalmatian-aarch64:
-            branches: main
+        # - container-images-kolla-push-caracal-aarch64:
+        #     branches: main
+        # - container-images-kolla-push-dalmatian-aarch64:
+        #     branches: main
     tag:
       jobs:
         - container-images-kolla-release


### PR DESCRIPTION
Will be fixed when the new Ampere and Bluefield-2 lab nodes are ready for use.