### PR TITLE
2024.2: use py-pure-client instead of purestorage

### DIFF
--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -55,7 +55,7 @@ RUN apt-get update ${"\\"}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}
 
-{% set cinder_volume_pip_packages = [ 'purestorage', 'infinisdk', 'python-linstor' ] %}
+{% set cinder_volume_pip_packages = [ 'py-pure-client', 'infinisdk', 'python-linstor' ] %}
 {% block cinder_volume_footer %}
 RUN {{ macros.install_pip(cinder_volume_pip_packages | customizable("pip_packages")) }}
 {% endblock %}


### PR DESCRIPTION
Install Pure Storage PyPI module. A requirement for the Pure Storage driver is the installation of the Pure Storage Python SDK version 1.47.0 or later from PyPI.