### PR TITLE
Don't make wget completely quiet

### DIFF
--- a/scripts/003-patch.sh
+++ b/scripts/003-patch.sh
@@ -37,7 +37,7 @@ for tarball in $(grep '# tarball' $KOLLA_CONF_FILE | awk '{ print $4 }'); do
     fi
 
     echo Download $tarball
-    wget --quiet $tarball
+    wget --no-verbose $tarball
 
     if [[ $tarball == *"gnocchi"* && ! $filename == *"gnocchi"* ]]; then
         mv $filename gnocchi-$filename


### PR DESCRIPTION
When a download fails, we still want to see the error message, so use the --no-verbose option for wget instead of --quiet.