### PR TITLE
Do not add version tags to heat images

### DIFF
--- a/etc/tag-images-with-the-version.yml
+++ b/etc/tag-images-with-the-version.yml
@@ -21,7 +21,6 @@ hacluster-corosync: dpkg -s corosync
 hacluster: dpkg -s pacemaker-common
 haproxy-ssh: dpkg -s openssh-server
 haproxy: dpkg -s haproxy
-heat: pip3 show openstack-heat
 horizon: pip3 show horizon
 influxdb: dpkg -s influxdb
 ironic: pip3 show ironic

--- a/src/get-projects-from-versions-file.py
+++ b/src/get-projects-from-versions-file.py
@@ -12,7 +12,6 @@ OPENSTACK_CORE_PROJECTS = [
     "cinder",
     "designate",
     "glance",
-    "heat",
     "horizon",
     "keystone",
     "neutron",

--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -248,7 +248,6 @@ SBOM_IMAGE_TO_VERSION = {
     "grafana": "grafana",
     "haproxy": "haproxy",
     "haproxy_ssh": "haproxy-ssh",
-    "heat": "heat-api",
     "horizon": "horizon",
     "influxdb": "influxdb",
     "ironic": "ironic-api",


### PR DESCRIPTION
We re-enabled the build of the heat images. We do not want to include them in stable releases again.