### PR TITLE
Add debian bookworm backport of open-iscsi

### DIFF
--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -115,6 +115,28 @@ RUN apt-get update ${"\\"}
     && a2enmod shib
 {% endblock %}
 
+##########################################
+# install open-iscsi bookworm-backport
+
+{% set osism_install_open_iscsi %}
+COPY --from=osism.harbor.regio.digital/packages/open-iscsi:bookworm-backports /*.deb /tmp/packages/
+RUN apt -y install -f /tmp/packages/libopeniscsiusr_*_amd64.deb -f /tmp/packages/open-iscsi_*_amd64.deb
+{% endset %}
+
+{% block base_footer %}
+{{ osism_install_open_iscsi }}
+{% endblock %}
+
+{% block nova_compute_footer %}
+{{ osism_install_open_iscsi }}
+{% endblock %}
+
+{% block iscsid_footer %}
+{{ osism_install_open_iscsi }}
+RUN rm -f /etc/iscsi/initiatorname.iscsi
+{% endblock %}
+##########################################
+
 {% block footer %}
 RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -115,6 +115,28 @@ RUN apt-get update ${"\\"}
     && a2enmod shib
 {% endblock %}
 
+##########################################
+# install open-iscsi bookworm-backport
+
+{% set osism_install_open_iscsi %}
+COPY --from=osism.harbor.regio.digital/packages/open-iscsi:bookworm-backports /*.deb /tmp/packages/
+RUN apt -y install -f /tmp/packages/libopeniscsiusr_*_amd64.deb -f /tmp/packages/open-iscsi_*_amd64.deb
+{% endset %}
+
+{% block base_footer %}
+{{ osism_install_open_iscsi }}
+{% endblock %}
+
+{% block nova_compute_footer %}
+{{ osism_install_open_iscsi }}
+{% endblock %}
+
+{% block iscsid_footer %}
+{{ osism_install_open_iscsi }} ${"\\"}
+RUN rm -f /etc/iscsi/initiatorname.iscsi
+{% endblock %}
+##########################################
+
 {% block footer %}
 RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}


### PR DESCRIPTION
Add the bookworm-backport of open-iscsi to the `base` container. Upstream kolla also explicitly installs `open-iscsi` in `nova_compute` and `iscsid`, so this is donw here as well.

Depends-On: https://github.com/osism/deb-packaging/pull/28