### PR TITLE
2024.2/2025.1: add virtual-media-nfs.patch

### DIFF
--- a/patches/2024.2/ironic/virtual-media-nfs.patch
+++ b/patches/2024.2/ironic/virtual-media-nfs.patch
@@ -1,0 +1,11 @@
+--- a/ironic/conf/deploy.py
++++ b/ironic/conf/deploy.py
+@@ -53,7 +53,7 @@
+                       "requires password credential. Currently utilized by "
+                       "the http_basic authentication strategy.")),
+     cfg.URIOpt('external_http_url',
+-               schemes=['http', 'https'],
++               schemes=['http', 'https', 'nfs'],
+                help=_("URL of the ironic-conductor node's HTTP server for "
+                       "boot methods such as virtual media, "
+                       "where images could be served outside of the "

--- a/patches/2025.1/ironic/virtual-media-nfs.patch
+++ b/patches/2025.1/ironic/virtual-media-nfs.patch
@@ -1,0 +1,11 @@
+--- a/ironic/conf/deploy.py
++++ b/ironic/conf/deploy.py
+@@ -53,7 +53,7 @@
+                       "requires password credential. Currently utilized by "
+                       "the http_basic authentication strategy.")),
+     cfg.URIOpt('external_http_url',
+-               schemes=['http', 'https'],
++               schemes=['http', 'https', 'nfs'],
+                help=_("URL of the ironic-conductor node's HTTP server for "
+                       "boot methods such as virtual media, "
+                       "where images could be served outside of the "


### PR DESCRIPTION
Add support for nfs:// scheme on Redfish virtual media boot.

Source:

https://github.com/scaleup-technologies/ironic-patches/tree/main/2024.2