### PR TITLE
2024.2/2025.1: add workaround-for-lp2095486.patch

### DIFF
--- a/patches/2024.2/ironic/workaround-for-lp2095486.patch
+++ b/patches/2024.2/ironic/workaround-for-lp2095486.patch
@@ -1,0 +1,11 @@
+--- a/ironic/drivers/modules/redfish/bios.py
++++ b/ironic/drivers/modules/redfish/bios.py
+@@ -29,7 +29,7 @@
+ 
+ registry_fields = ('attribute_type', 'allowable_values', 'lower_bound',
+                    'max_length', 'min_length', 'read_only',
+-                   'reset_required', 'unique', 'upper_bound')
++                   'reset_required', 'unique')
+ 
+ 
+ class RedfishBIOS(base.BIOSInterface):

--- a/patches/2025.1/ironic/workaround-for-lp2095486.patch
+++ b/patches/2025.1/ironic/workaround-for-lp2095486.patch
@@ -1,0 +1,11 @@
+--- a/ironic/drivers/modules/redfish/bios.py
++++ b/ironic/drivers/modules/redfish/bios.py
+@@ -29,7 +29,7 @@
+ 
+ registry_fields = ('attribute_type', 'allowable_values', 'lower_bound',
+                    'max_length', 'min_length', 'read_only',
+-                   'reset_required', 'unique', 'upper_bound')
++                   'reset_required', 'unique')
+ 
+ 
+ class RedfishBIOS(base.BIOSInterface):


### PR DESCRIPTION
Do not store upper_bound BIOS attributes, fix for
https://bugs.launchpad.net/ironic/+bug/2095486

Source:

https://github.com/scaleup-technologies/ironic-patches/tree/main/2024.2