### PR TITLE
2024.2/2025.1: add backport-964771.patch

### DIFF
--- a/patches/2024.2/ironic/backport-964771.patch
+++ b/patches/2024.2/ironic/backport-964771.patch
@@ -1,0 +1,120 @@
+From d32a9e0df2125c15d20fb59baebe14e7859bbd4d Mon Sep 17 00:00:00 2001
+From: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Date: Fri, 24 Oct 2025 14:17:46 +0200
+Subject: [PATCH] Set upper_bound column in bios_settings table to bigint
+
+Currently the column is set to a signed int, causing issues for systems reporting larger values. The value of upper_bound can be up to 32-bit unsigned as per redfish standard.
+
+This patch will change the data type to BigInteger, which will allow the larger values to be stored.
+
+Change-Id: Ife9742784c8d59fd5c6b89757e215938ec0a595d
+Closes-Bug: #2095486
+Signed-off-by: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+---
+
+diff --git a/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+new file mode 100644
+index 0000000..0236008
+--- /dev/null
++++ b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+@@ -0,0 +1,36 @@
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++
++"""set upper_bound to bigint
++
++Revision ID: 9c0446cb6bc3
++Revises: 66bd9c5604d5
++Create Date: 2025-10-24 13:30:47.070830
++
++"""
++
++# revision identifiers, used by Alembic.
++revision = '9c0446cb6bc3'
++down_revision = '66bd9c5604d5'
++
++from alembic import op
++import sqlalchemy as sa
++
++
++def upgrade():
++    pass
++
++def upgrade():
++    op.alter_column('bios_settings', 'upper_bound',
++                    existing_type=sa.Integer(),
++                    type_=sa.BigInteger(),
++                    existing_nullable=True)
+diff --git a/ironic/db/sqlalchemy/models.py b/ironic/db/sqlalchemy/models.py
+index fbe5c1f..ada96f8 100644
+--- a/ironic/db/sqlalchemy/models.py
++++ b/ironic/db/sqlalchemy/models.py
+@@ -27,7 +27,7 @@
+ from oslo_db.sqlalchemy import types as db_types
+ from sqlalchemy.ext.associationproxy import association_proxy
+ from sqlalchemy import Boolean, Column, DateTime, false, Index
+-from sqlalchemy import ForeignKey, Integer
++from sqlalchemy import ForeignKey, Integer, BigInteger
+ from sqlalchemy import schema, String, Text
+ from sqlalchemy import orm
+ from sqlalchemy.orm import declarative_base
+@@ -399,7 +399,7 @@
+     read_only = Column(Boolean, nullable=True)
+     reset_required = Column(Boolean, nullable=True)
+     unique = Column(Boolean, nullable=True)
+-    upper_bound = Column(Integer, nullable=True)
++    upper_bound = Column(BigInteger, nullable=True)
+ 
+ 
+ class Allocation(Base):
+diff --git a/ironic/tests/unit/db/sqlalchemy/test_migrations.py b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+index 7b6b55a..dc94d2a 100644
+--- a/ironic/tests/unit/db/sqlalchemy/test_migrations.py
++++ b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+@@ -1592,6 +1592,23 @@
+         self.assertIsInstance(node_inventory.c.plugin_data.type,
+                               sqlalchemy.dialects.mysql.LONGTEXT)
+ 
++    def _check_9c0446cb6bc3(self, engine, data):
++        bios_settings = db_utils.get_table(engine, 'bios_settings')
++        node_id = "1234"
++        name = "CbsCmnBoostFmax"
++        upper_bound = 4294967295
++
++        data = {'node_id': node_id, 'name': name, 'upper_bound': upper_bound}
++        with engine.begin() as connection:
++            insert_setting = bios_settings.insert().values(data)
++            connection.execute(insert_setting)
++            bios_setting_stmt = sqlalchemy.select(
++                models.BIOSSetting.upper_bound
++            ).where(
++                models.BIOSSetting.node_id == node_id
++            )
++            bios_setting = connection.execute(bios_setting_stmt).first()
++            self.assertEqual(upper_bound, bios_setting.upper_bound)
+ 
+ class TestMigrationsPostgreSQL(MigrationCheckersMixin,
+                                WalkVersionsMixin,
+diff --git a/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+new file mode 100644
+index 0000000..52611d0e
+--- /dev/null
++++ b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+@@ -0,0 +1,8 @@
++---
++upgrade:
++  - Change the ``upper_bound`` column in the bios_settings table from Integer
++    to BigInteger to store bigger values
++fixes:
++  - The upper_bound BIOS setting attribute can now be a larger integer.
++    Please see `bug 2095486 <https://bugs.launchpad.net/ironic/+bug/2095486>`_
++    for more information.

--- a/patches/2025.1/ironic/backport-964771.patch
+++ b/patches/2025.1/ironic/backport-964771.patch
@@ -1,0 +1,120 @@
+From d32a9e0df2125c15d20fb59baebe14e7859bbd4d Mon Sep 17 00:00:00 2001
+From: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Date: Fri, 24 Oct 2025 14:17:46 +0200
+Subject: [PATCH] Set upper_bound column in bios_settings table to bigint
+
+Currently the column is set to a signed int, causing issues for systems reporting larger values. The value of upper_bound can be up to 32-bit unsigned as per redfish standard.
+
+This patch will change the data type to BigInteger, which will allow the larger values to be stored.
+
+Change-Id: Ife9742784c8d59fd5c6b89757e215938ec0a595d
+Closes-Bug: #2095486
+Signed-off-by: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+---
+
+diff --git a/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+new file mode 100644
+index 0000000..0236008
+--- /dev/null
++++ b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+@@ -0,0 +1,36 @@
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++
++"""set upper_bound to bigint
++
++Revision ID: 9c0446cb6bc3
++Revises: 66bd9c5604d5
++Create Date: 2025-10-24 13:30:47.070830
++
++"""
++
++# revision identifiers, used by Alembic.
++revision = '9c0446cb6bc3'
++down_revision = '66bd9c5604d5'
++
++from alembic import op
++import sqlalchemy as sa
++
++
++def upgrade():
++    pass
++
++def upgrade():
++    op.alter_column('bios_settings', 'upper_bound',
++                    existing_type=sa.Integer(),
++                    type_=sa.BigInteger(),
++                    existing_nullable=True)
+diff --git a/ironic/db/sqlalchemy/models.py b/ironic/db/sqlalchemy/models.py
+index fbe5c1f..ada96f8 100644
+--- a/ironic/db/sqlalchemy/models.py
++++ b/ironic/db/sqlalchemy/models.py
+@@ -27,7 +27,7 @@
+ from oslo_db.sqlalchemy import types as db_types
+ from sqlalchemy.ext.associationproxy import association_proxy
+ from sqlalchemy import Boolean, Column, DateTime, false, Index
+-from sqlalchemy import ForeignKey, Integer
++from sqlalchemy import ForeignKey, Integer, BigInteger
+ from sqlalchemy import schema, String, Text
+ from sqlalchemy import orm
+ from sqlalchemy.orm import declarative_base
+@@ -399,7 +399,7 @@
+     read_only = Column(Boolean, nullable=True)
+     reset_required = Column(Boolean, nullable=True)
+     unique = Column(Boolean, nullable=True)
+-    upper_bound = Column(Integer, nullable=True)
++    upper_bound = Column(BigInteger, nullable=True)
+ 
+ 
+ class Allocation(Base):
+diff --git a/ironic/tests/unit/db/sqlalchemy/test_migrations.py b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+index 7b6b55a..dc94d2a 100644
+--- a/ironic/tests/unit/db/sqlalchemy/test_migrations.py
++++ b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+@@ -1592,6 +1592,23 @@
+         self.assertIsInstance(node_inventory.c.plugin_data.type,
+                               sqlalchemy.dialects.mysql.LONGTEXT)
+ 
++    def _check_9c0446cb6bc3(self, engine, data):
++        bios_settings = db_utils.get_table(engine, 'bios_settings')
++        node_id = "1234"
++        name = "CbsCmnBoostFmax"
++        upper_bound = 4294967295
++
++        data = {'node_id': node_id, 'name': name, 'upper_bound': upper_bound}
++        with engine.begin() as connection:
++            insert_setting = bios_settings.insert().values(data)
++            connection.execute(insert_setting)
++            bios_setting_stmt = sqlalchemy.select(
++                models.BIOSSetting.upper_bound
++            ).where(
++                models.BIOSSetting.node_id == node_id
++            )
++            bios_setting = connection.execute(bios_setting_stmt).first()
++            self.assertEqual(upper_bound, bios_setting.upper_bound)
+ 
+ class TestMigrationsPostgreSQL(MigrationCheckersMixin,
+                                WalkVersionsMixin,
+diff --git a/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+new file mode 100644
+index 0000000..52611d0e
+--- /dev/null
++++ b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+@@ -0,0 +1,8 @@
++---
++upgrade:
++  - Change the ``upper_bound`` column in the bios_settings table from Integer
++    to BigInteger to store bigger values
++fixes:
++  - The upper_bound BIOS setting attribute can now be a larger integer.
++    Please see `bug 2095486 <https://bugs.launchpad.net/ironic/+bug/2095486>`_
++    for more information.


### PR DESCRIPTION
Set upper_bound column in bios_settings table to bigint

Currently the column is set to a signed int, causing issues for systems reporting larger values. The value of upper_bound can be up to 32-bit unsigned as per redfish standard.

This patch will change the data type to BigInteger, which will allow the larger values to be stored.

https://review.opendev.org/c/openstack/ironic/+/964771