### PR TITLE
Fix OVN version detection to use OPENSTACK_VERSION

### DIFF
--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -13,12 +13,13 @@ from yaml import dump, safe_load, YAMLError
 
 IS_RELEASE = os.environ.get("IS_RELEASE", "False")
 TAG_POSTFIX = os.environ.get("TAG_POSTFIX", None)
+OPENSTACK_VERSION = os.environ.get("OPENSTACK_VERSION", "zed")
 
 if IS_RELEASE == "True":
     VERSION = os.environ.get("VERSION", "zed")
     FILTERS = {"label": f"de.osism.version={VERSION}"}
 else:
-    VERSION = os.environ.get("OPENSTACK_VERSION", "zed")
+    VERSION = OPENSTACK_VERSION
     FILTERS = {"label": f"de.osism.release.openstack={VERSION}"}
 
 with open("etc/tag-images-with-the-version.yml", "r") as fp:
@@ -87,7 +88,7 @@ for image in client.images.list(filters=FILTERS):
             logger.error(f"Configuration for {name} ({best_key}) not found")
             continue
 
-        if best_key == "ovn" and VERSION in ["2024.1", "2024.2"]:
+        if best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
             command = "ovn-controller --version"
         else:
             command = configuration[best_key]
@@ -124,7 +125,7 @@ for image in client.images.list(filters=FILTERS):
                 # 2.0.1 (Commit:fa14705e51bd2ce5)
                 r = findall(r"(.*) \(Commit:", result)
 
-            elif best_key == "ovn" and VERSION in ["2024.1", "2024.2"]:
+            elif best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
                 # ovn-controller 22.03.0
                 r = findall(r"ovn-controller (.*)\n", result)
 


### PR DESCRIPTION
The OVN version check was incorrectly using VERSION which differs between release and non-release builds. This uses OPENSTACK_VERSION consistently for the OVN-specific logic.