### PR TITLE
Add nvme-cli package to glance base images

### DIFF
--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -53,6 +53,8 @@ RUN apt-get update ${"\\"}
     && rm -rf /var/lib/apt/lists/*
 {% endblock %}
 
+{% set glance_base_packages_append = ['nvme-cli'] %}
+
 {% set kolla_toolbox_packages_append = ['iputils-ping', 'traceroute'] %}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -53,6 +53,8 @@ RUN apt-get update ${"\\"}
     && rm -rf /var/lib/apt/lists/*
 {% endblock %}
 
+{% set glance_base_packages_append = ['nvme-cli'] %}
+
 {% set kolla_toolbox_packages_append = ['iputils-ping', 'traceroute'] %}
 
 {% set cinder_volume_packages_append = ['multipath-tools'] %}


### PR DESCRIPTION
This adds nvme-cli to glance_base_packages_append for both 2024.2 and 2025.1 releases to support NVMe storage backends.

Part of osism/issues#1327