### PR TITLE
Fix version detection for libvirt and openstack exporters

### DIFF
--- a/etc/tag-images-with-the-version.yml
+++ b/etc/tag-images-with-the-version.yml
@@ -66,7 +66,7 @@ prometheus-elasticsearch-exporter: bash -c '/opt/elasticsearch_exporter/elastics
 # haproxy_exporter, version 0.10.0 (branch: HEAD, revision: ec68a7b1129651dff5b4268dd1e423571652ca60)
 prometheus-haproxy-exporter: bash -c '/opt/haproxy_exporter/haproxy_exporter --version 2>&1'
 # Version of Kolla is used
-prometheus-libvirt-exporter: echo
+prometheus-libvirt-exporter: bash -c '/opt/libvirt-exporter --version 2>&1'
 # memcached_exporter, version 0.6.0 (branch: HEAD, revision: d7eadc3523ec9731b7865a188093f70140d54a8d)
 prometheus-memcached-exporter: bash -c '/opt/memcached_exporter/memcached_exporter --version 2>&1'
 # v1.5.1
@@ -77,8 +77,8 @@ prometheus-mtail: bash -c '/opt/mtail --version 2>&1'
 prometheus-mysqld-exporter: bash -c '/opt/mysqld_exporter/mysqld_exporter --version 2>&1'
 # node_exporter, version 0.18.1 (branch: HEAD, revision: 3db77732e925c08f675d7404a8c46466b2ece83e)
 prometheus-node-exporter: bash -c '/opt/node_exporter/node_exporter --version 2>&1'
-# openstack-exporter, version 1.3.0 (branch: HEAD, revision: b33bff9801ebcd714d9d08cabde8997101afe938)
-prometheus-openstack-exporter: echo
+# 4827ad4a95c3af9f56c026e168168050429793c3406c0330b9f9c4049e8bca3f  /opt/openstack-exporter/openstack-exporter
+prometheus-openstack-exporter: bash -c 'sha256sum /opt/openstack-exporter/openstack-exporter 2>&1'
 # ovn-exporter 1.0.4
 prometheus-ovn-exporter: /opt/ovn-exporter --version
 # prometheus, version 2.26.1 (branch: HEAD, revision: 6eeded0fdf760e81af75d9c44ce539ab77da4505)

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -23,6 +23,8 @@
 
           export PATH=/home/zuul/.local/bin:$PATH
 
+          echo $COMMIT_MESSAGE
+
           bash scripts/001-prepare.sh
           bash scripts/002-generate.sh
           bash scripts/003-patch.sh
@@ -36,6 +38,7 @@
         IS_RELEASE: "{{ is_release | default(false) }}"
         OPENSTACK_VERSION: "{{ version_openstack | default('latest') }}"
         VERSION: "{{ zuul['tag'] | default('latest') }}"
+        COMMIT_MESSAGE: "{{ zuul['change_message'] | default('') }}"
 
     - name: Run push script
       ansible.builtin.shell:

--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -105,13 +105,20 @@ for image in client.images.list(filters=FILTERS):
             )
             result = result.decode("utf-8")
 
-            # NOTE: the libvirt_export binary has no --version argument
-            # https://github.com/osism/container-images-kolla/issues/143
             if best_key == "prometheus-libvirt-exporter":
-                r = [VERSION]
+                # libvirt_exporter, version 2.2.0 (branch: , revision: unknown
+                r = findall(r"libvirt_exporter, version (.*) \(branch", result)
 
             elif best_key == "prometheus-openstack-exporter":
-                r = [VERSION]
+                # 4827ad4a95c3af9f56c026e168168050429793c3406c0330b9f9c4049e8bca3f  /opt/openstack-exporter/openstack-exporter
+                checksum = findall(r"(\S+)\s*\/opt", result)
+                if (
+                    "4827ad4a95c3af9f56c026e168168050429793c3406c0330b9f9c4049e8bca3f"
+                    in checksum
+                ):
+                    r = ["1.7.0"]
+                else:
+                    r = [image.labels["de.osism.commit.kolla_version"]]
 
             elif best_key == "prometheus-ovn-exporter":
                 # ovn-exporter 1.0.4


### PR DESCRIPTION
- prometheus-libvirt-exporter: Use --version flag to get actual version
  instead of falling back to Kolla version
- prometheus-openstack-exporter: Identify version 1.7.0 via SHA256 checksum
  since binary lacks version flag
- Add NO-SBOM-CHECK directive to exclude specific images from SBOM
  comparison via commit message (format: "NO-SBOM-CHECK: <image-name>")
- Update version detection commands in tag-images-with-the-version.yml

NO-SBOM-CHECK: prometheus-libvirt-exporter
NO-SBOM-CHECK: prometheus-openstack-exporter