### PR TITLE
Add OpenStack version to release image namespace

### DIFF
--- a/scripts/005-tag.sh
+++ b/scripts/005-tag.sh
@@ -51,7 +51,12 @@ docker images -f label="de.osism.release.openstack=${OPENSTACK_VERSION}" | tail 
         # http://stackoverflow.com/questions/12766406/how-to-get-the-first-part-of-the-string-in-bash
         project=${new_imagename%%-*}
 
-        new_imagename="$DOCKER_NAMESPACE/$new_imagename"
+        # For releases, add /release/$OPENSTACK_VERSION to the namespace
+        if [[ $IS_RELEASE == "True" ]]; then
+            new_imagename="$DOCKER_NAMESPACE/release/$OPENSTACK_VERSION/$new_imagename"
+        else
+            new_imagename="$DOCKER_NAMESPACE/$new_imagename"
+        fi
         if [[ ! -z $DOCKER_REGISTRY ]]; then
             new_imagename="$DOCKER_REGISTRY/$new_imagename"
         fi
@@ -89,9 +94,9 @@ python3 src/compare-sbom.py || exit 1
 
 if [[ $VERSION != "latest" ]]; then
     sbom_version="${VERSION:1:${#VERSION}-1}"
-    docker build -t $DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/sbom:$sbom_version .
-    echo "$DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/sbom:$sbom_version" >> $LSTFILE
-    echo "$DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/sbom:$sbom_version" >> images.lst
+    docker build -t $DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/$OPENSTACK_VERSION/sbom:$sbom_version .
+    echo "$DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/$OPENSTACK_VERSION/sbom:$sbom_version" >> $LSTFILE
+    echo "$DOCKER_REGISTRY/$DOCKER_NAMESPACE/release/$OPENSTACK_VERSION/sbom:$sbom_version" >> images.lst
 else
     docker build -t $DOCKER_REGISTRY/$DOCKER_NAMESPACE/sbom:$OPENSTACK_VERSION .
     echo "$DOCKER_REGISTRY/$DOCKER_NAMESPACE/sbom:$OPENSTACK_VERSION" >> $LSTFILE

--- a/scripts/120-check-and-repush.sh
+++ b/scripts/120-check-and-repush.sh
@@ -245,8 +245,8 @@ main() {
     if [[ ! -f "$IMAGES_FILE" ]]; then
         log_error "Images file not found: $IMAGES_FILE"
         log_info "Expected format: one image per line, e.g.:"
-        log_info "  osism.harbor.regio.digital/kolla/release/sbom:0.20250928.0"
-        log_info "  osism.harbor.regio.digital/osism/nova-compute:2024.1"
+        log_info "  osism.harbor.regio.digital/kolla/release/2025.1/sbom:7.2.0"
+        log_info "  osism.harbor.regio.digital/kolla/release/2025.1/nova-compute:28.0.1.20251207"
         exit 1
     fi
 
@@ -449,8 +449,8 @@ usage() {
     echo
     echo "Images file format:"
     echo "  One image per line, e.g.:"
-    echo "  osism.harbor.regio.digital/kolla/release/sbom:0.20250928.0"
-    echo "  osism.harbor.regio.digital/osism/nova-compute:2024.1"
+    echo "  osism.harbor.regio.digital/kolla/release/2025.1/sbom:7.2.0"
+    echo "  osism.harbor.regio.digital/kolla/release/2025.1/nova-compute:28.0.1.20251207"
 }
 
 # Parse command line arguments

--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -216,9 +216,11 @@ for image in client.images.list(filters=FILTERS):
                         f"Tag postfix '{TAG_POSTFIX}. is defined, extended tag is {target_tag}."
                     )
 
-                # Move release images to a release subproject
+                # Move release images to a release subproject with OpenStack version
                 if IS_RELEASE == "True":
-                    target_tag = target_tag.replace("/kolla/", "/kolla/release/")
+                    target_tag = target_tag.replace(
+                        "/kolla/", f"/kolla/release/{OPENSTACK_VERSION}/"
+                    )
 
                 logger.info(
                     f"Adding org.opencontainers.image.version='{target_version}' label to {tag}"


### PR DESCRIPTION
For release builds, images are now tagged with the OpenStack version in the namespace path (e.g., kolla/release/2025.1/nova-compute instead of kolla/release/nova-compute). This allows better association of releases with their corresponding OpenStack version.

AI-assisted: Claude Code