### PR TITLE
Fix duplicate release namespace in SBOM image paths

### DIFF
--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -218,9 +218,9 @@ for image in client.images.list(filters=FILTERS):
 
                 # Move release images to a release subproject with OpenStack version
                 if IS_RELEASE == "True":
-                    target_tag = target_tag.replace(
-                        "/kolla/", f"/kolla/release/{OPENSTACK_VERSION}/"
-                    )
+                    release_namespace = f"/kolla/release/{OPENSTACK_VERSION}/"
+                    if release_namespace not in target_tag:
+                        target_tag = target_tag.replace("/kolla/", release_namespace)
 
                 logger.info(
                     f"Adding org.opencontainers.image.version='{target_version}' label to {tag}"


### PR DESCRIPTION
Check if the release namespace already exists in the tag before adding it to prevent paths like release/2025.1/release/2025.1/image-name.

Related to 56adaac8ddc79c4c730993ea4dbca73126722032