### PR TITLE
Fix keystone DB bootstrap error

### DIFF
--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,3 +5,10 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
+
+# Remove the pin for proxysql once
+# https://github.com/sysown/proxysql/pull/5277
+# is merged or otherwise resolved or worked around
+Package: proxysql*
+Pin: version 3.0.3
+Pin-Priority: 1000

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,3 +9,10 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+# Remove the pin for proxysql once
+# https://github.com/sysown/proxysql/pull/5277
+# is merged or otherwise resolved or worked around
+Package: proxysql*
+Pin: version 3.0.3
+Pin-Priority: 1000


### PR DESCRIPTION
With version 3.0.4 proxysql started to answer with its own version when queried with `select version()` instead of proxying the query to its conbfigured backend. This leads sqlalchemy to try and query for `transaction_isolation` instead of `trx_isolation` where the former does not exist in mariadb.
Therefore proxysql is pinned to version 3.3.