### PR TITLE
Remove Shibboleth module from keystone images

### DIFF
--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -95,15 +95,12 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
-           libapache2-mod-shib ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}
            libldap-common ${"\\"}
            libmemcached11 ${"\\"}
     && apt-get clean ${"\\"}
     && rm -rf /var/lib/apt/lists/* ${"\\"}
-    && a2enmod auth_openidc ${"\\"}
-    && a2dismod shib ${"\\"}
-    && rm -f /etc/apache2/conf-enabled/shib.conf
+    && a2enmod auth_openidc
 {% endblock %}
 
 {% block footer %}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -93,15 +93,12 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
-           libapache2-mod-shib ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}
            libldap-common ${"\\"}
            libmemcached11 ${"\\"}
     && apt-get clean ${"\\"}
     && rm -rf /var/lib/apt/lists/* ${"\\"}
-    && a2enmod auth_openidc ${"\\"}
-    && a2dismod shib ${"\\"}
-    && rm -f /etc/apache2/conf-enabled/shib.conf
+    && a2enmod auth_openidc
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
The libapache2-mod-shib package and related Apache configuration are no longer needed. Only OpenID Connect (mod_auth_openidc) is retained for federated authentication.

We will provide a special image in the future using only Shibboleth modules.