### PR TITLE
Fix CVE-2026-22797 in keystonemiddleware (OSSA-2026-001)

### DIFF
--- a/patches/2024.1/openstack_requirements/keystonemiddleware.patch
+++ b/patches/2024.1/openstack_requirements/keystonemiddleware.patch
@@ -1,0 +1,20 @@
+--- a/upper-constraints.txt
++++ b/upper-constraints.txt
+@@ -366,7 +366,7 @@ infi.dtypes.iqn===0.4.0
+ XStatic-tv4===1.2.7.0
+ XStatic-JSEncrypt===2.3.1.1
+ python-cinderclient===9.5.0
+-keystonemiddleware===10.6.0
++keystonemiddleware===10.12.1
+ django-formtools===2.5.1
+ XStatic-Spin===1.2.5.3
+ tap-as-a-service===13.0.0.0rc1
+@@ -385,7 +385,7 @@ protobuf===4.25.3
+ sushy===5.0.1
+ python-neutronclient===11.2.0
+ pika===1.3.2
+-oslo.cache===3.7.0
++oslo.cache===3.11.0
+ WebTest===3.0.0
+ openstack.nose-plugin===0.11
+ os-collect-config===13.2.0

--- a/patches/2024.2/openstack_requirements/keystonemiddleware.patch
+++ b/patches/2024.2/openstack_requirements/keystonemiddleware.patch
@@ -1,0 +1,20 @@
+--- a/upper-constraints.txt
++++ b/upper-constraints.txt
+@@ -368,7 +368,7 @@ infi.dtypes.iqn===0.4.0
+ XStatic-tv4===1.2.7.0
+ XStatic-JSEncrypt===2.3.1.1
+ python-cinderclient===9.6.0
+-keystonemiddleware===10.7.1
++keystonemiddleware===10.12.1
+ django-formtools===2.5.1
+ XStatic-Spin===1.2.5.3
+ tap-as-a-service===14.0.0.0rc1
+@@ -386,7 +386,7 @@ sushy===5.2.1
+ python-neutronclient===11.3.1
+ types-setuptools===73.0.0.20240822
+ pika===1.3.2
+-oslo.cache===3.8.0
++oslo.cache===3.11.0
+ WebTest===3.0.0
+ os-collect-config===14.0.0
+ edgegrid-python===1.3.1

--- a/patches/2025.1/openstack_requirements/keystonemiddleware.patch
+++ b/patches/2025.1/openstack_requirements/keystonemiddleware.patch
@@ -1,0 +1,20 @@
+--- a/upper-constraints.txt
++++ b/upper-constraints.txt
+@@ -354,7 +354,7 @@ infi.dtypes.iqn===0.4.0
+ XStatic-tv4===1.2.7.0
+ XStatic-JSEncrypt===2.3.1.1
+ python-cinderclient===9.7.0
+-keystonemiddleware===10.9.0
++keystonemiddleware===10.12.1
+ django-formtools===2.5.1
+ XStatic-Spin===1.2.5.3
+ rich===13.9.4
+@@ -373,7 +373,7 @@ sushy===5.5.0
+ python-neutronclient===11.4.0
+ types-setuptools===75.8.0.20250210
+ pika===1.3.2
+-oslo.cache===3.10.2
++oslo.cache===3.11.0
+ WebTest===3.0.4
+ os-collect-config===14.0.0
+ edgegrid-python===2.0.0


### PR DESCRIPTION
Update keystonemiddleware to 11.0.0 for 2024.1, 2024.2 and 2025.1 to address a security vulnerability in the external_oauth2_token middleware that allows attackers to forge identity headers and escalate privileges.