### PR TITLE
Revert "Fix keystone DB bootstrap error"

### DIFF
--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,10 +5,3 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
-
-# Remove the pin for proxysql once
-# https://github.com/sysown/proxysql/pull/5277
-# is merged or otherwise resolved or worked around
-Package: proxysql*
-Pin: version 3.0.3
-Pin-Priority: 1000

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,10 +9,3 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
-
-# Remove the pin for proxysql once
-# https://github.com/sysown/proxysql/pull/5277
-# is merged or otherwise resolved or worked around
-Package: proxysql*
-Pin: version 3.0.3
-Pin-Priority: 1000


### PR DESCRIPTION
This reverts commit 186ea8b977b94db8e7fff1d389e61562e88438dc.

ProxySQL version 3.0.5 has been released with a fix for this issue ([1]).

[1]
https://github.com/sysown/proxysql/pull/5277