### PR TITLE
Add ironic/backport-968348.patch

### DIFF
--- a/patches/2024.2/ironic/backport-968348.patch
+++ b/patches/2024.2/ironic/backport-968348.patch
@@ -1,0 +1,153 @@
+From fc569949edf5480242df10394bf6e2643886b231 Mon Sep 17 00:00:00 2001
+From: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Date: Fri, 24 Oct 2025 14:17:46 +0200
+Subject: [PATCH] Set columns in bios_settings table to bigint
+
+Currently the columns upper_bound and lower_bound are set to a signed
+int, causing issues for systems reporting larger values. The values can
+be up to 32-bit unsigned as per redfish standard.
+
+This patch will change the data type to BigInteger, which will allow the
+larger values to be stored.
+
+Change-Id: Ife9742784c8d59fd5c6b89757e215938ec0a595d
+Closes-Bug: #2095486
+Signed-off-by: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Signed-off-by: ricolin <rlin@vexxhost.com>
+---
+
+diff --git a/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+new file mode 100644
+index 0000000..053852f
+--- /dev/null
++++ b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+@@ -0,0 +1,33 @@
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++
++from alembic import op
++import sqlalchemy as sa
++
++"""set upper_bound and lower_bound to bigint
++
++Revision ID: 9c0446cb6bc3
++Revises: 9f8c7d6e5b4a
++Create Date: 2025-10-24 13:30:47.070830
++
++"""
++
++# revision identifiers, used by Alembic.
++revision = '9c0446cb6bc3'
++down_revision = '9f8c7d6e5b4a'
++
++
++def upgrade():
++    op.alter_column('bios_settings', 'upper_bound', existing_type=sa.Integer(),
++                    type_=sa.BigInteger(), existing_nullable=True)
++    op.alter_column('bios_settings', 'lower_bound', existing_type=sa.Integer(),
++                    type_=sa.BigInteger(), existing_nullable=True)
+diff --git a/ironic/db/sqlalchemy/models.py b/ironic/db/sqlalchemy/models.py
+index 71a621f..c666e49 100644
+--- a/ironic/db/sqlalchemy/models.py
++++ b/ironic/db/sqlalchemy/models.py
+@@ -27,7 +27,7 @@
+ from oslo_db.sqlalchemy import types as db_types
+ from sqlalchemy.ext.associationproxy import association_proxy
+ from sqlalchemy import Boolean, Column, DateTime, false, Index
+-from sqlalchemy import ForeignKey, Integer
++from sqlalchemy import BigInteger, ForeignKey, Integer
+ from sqlalchemy import schema, String, Text
+ from sqlalchemy import orm
+ from sqlalchemy.orm import declarative_base
+@@ -402,13 +402,13 @@
+     value = Column(Text, nullable=True)
+     attribute_type = Column(String(255), nullable=True)
+     allowable_values = Column(db_types.JsonEncodedList, nullable=True)
+-    lower_bound = Column(Integer, nullable=True)
++    lower_bound = Column(BigInteger, nullable=True)
+     max_length = Column(Integer, nullable=True)
+     min_length = Column(Integer, nullable=True)
+     read_only = Column(Boolean, nullable=True)
+     reset_required = Column(Boolean, nullable=True)
+     unique = Column(Boolean, nullable=True)
+-    upper_bound = Column(Integer, nullable=True)
++    upper_bound = Column(BigInteger, nullable=True)
+ 
+ 
+ class Allocation(Base):
+diff --git a/ironic/tests/unit/db/sqlalchemy/test_migrations.py b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+index 5ff0ef2..187fcfb 100644
+--- a/ironic/tests/unit/db/sqlalchemy/test_migrations.py
++++ b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+@@ -1490,6 +1490,47 @@
+             )
+             connection.execute(del_stmt)
+ 
++    def _pre_upgrade_9c0446cb6bc3(self, engine):
++        # Create a node to which bios_settings can be added.
++        data = {'uuid': uuidutils.generate_uuid()}
++        nodes = db_utils.get_table(engine, 'nodes')
++        with engine.begin() as connection:
++            insert_node = nodes.insert().values(data)
++            connection.execute(insert_node)
++            node_stmt = sqlalchemy.select(
++                models.Node.id
++            ).where(
++                models.Node.uuid == data['uuid']
++            )
++            node = connection.execute(node_stmt).first()
++            # WARNING: Always copy, never directly return a db object or
++            # piece of a db object. It is a sqlalchemy thing.
++            data['id'] = int(node.id)
++        return data
++
++    def _check_9c0446cb6bc3(self, engine, data):
++        bios_settings = db_utils.get_table(engine, 'bios_settings')
++        node_id = data['id']
++        name = "CbsCmnBoostFmax"
++        # Test max 32-bit unsigned value
++        upper_bound = 4294967295
++        lower_bound = 4294967295
++
++        setting_data = {'node_id': node_id, 'name': name,
++                        'upper_bound': upper_bound, 'lower_bound': lower_bound}
++        with engine.begin() as connection:
++            insert_setting = bios_settings.insert().values(setting_data)
++            connection.execute(insert_setting)
++            bios_setting_stmt = sqlalchemy.select(
++                models.BIOSSetting.upper_bound,
++                models.BIOSSetting.lower_bound
++            ).where(
++                models.BIOSSetting.node_id == node_id
++            )
++            bios_setting = connection.execute(bios_setting_stmt).first()
++            self.assertEqual(upper_bound, bios_setting.upper_bound)
++            self.assertEqual(lower_bound, bios_setting.lower_bound)
++
+     def test_upgrade_and_version(self):
+         with patch_with_engine(self.engine):
+             self.migration_api.upgrade('head')
+diff --git a/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+new file mode 100644
+index 0000000..b0abbdf
+--- /dev/null
++++ b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+@@ -0,0 +1,9 @@
++---
++upgrade:
++  - Change the ``upper_bound`` and ``lower_bound`` columns in the
++    ``bios_settings`` table from Integer to BigInteger to store bigger values.
++fixes:
++  - The ``upper_bound`` and ``lower_bound`` BIOS setting attributes can now be
++    larger integers (up to 32-bit unsigned values as per Redfish standard).
++    Please see `bug 2095486 <https://bugs.launchpad.net/ironic/+bug/2095486>`_
++    for more information.

--- a/patches/2025.1/ironic/backport-968348.patch
+++ b/patches/2025.1/ironic/backport-968348.patch
@@ -1,0 +1,153 @@
+From fc569949edf5480242df10394bf6e2643886b231 Mon Sep 17 00:00:00 2001
+From: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Date: Fri, 24 Oct 2025 14:17:46 +0200
+Subject: [PATCH] Set columns in bios_settings table to bigint
+
+Currently the columns upper_bound and lower_bound are set to a signed
+int, causing issues for systems reporting larger values. The values can
+be up to 32-bit unsigned as per redfish standard.
+
+This patch will change the data type to BigInteger, which will allow the
+larger values to be stored.
+
+Change-Id: Ife9742784c8d59fd5c6b89757e215938ec0a595d
+Closes-Bug: #2095486
+Signed-off-by: Freerk-Ole Zakfeld <fzakfeld@scaleuptech.com>
+Signed-off-by: ricolin <rlin@vexxhost.com>
+---
+
+diff --git a/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+new file mode 100644
+index 0000000..053852f
+--- /dev/null
++++ b/ironic/db/sqlalchemy/alembic/versions/9c0446cb6bc3_set_upper_bound_to_bigint.py
+@@ -0,0 +1,33 @@
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++
++from alembic import op
++import sqlalchemy as sa
++
++"""set upper_bound and lower_bound to bigint
++
++Revision ID: 9c0446cb6bc3
++Revises: 9f8c7d6e5b4a
++Create Date: 2025-10-24 13:30:47.070830
++
++"""
++
++# revision identifiers, used by Alembic.
++revision = '9c0446cb6bc3'
++down_revision = '9f8c7d6e5b4a'
++
++
++def upgrade():
++    op.alter_column('bios_settings', 'upper_bound', existing_type=sa.Integer(),
++                    type_=sa.BigInteger(), existing_nullable=True)
++    op.alter_column('bios_settings', 'lower_bound', existing_type=sa.Integer(),
++                    type_=sa.BigInteger(), existing_nullable=True)
+diff --git a/ironic/db/sqlalchemy/models.py b/ironic/db/sqlalchemy/models.py
+index 71a621f..c666e49 100644
+--- a/ironic/db/sqlalchemy/models.py
++++ b/ironic/db/sqlalchemy/models.py
+@@ -27,7 +27,7 @@
+ from oslo_db.sqlalchemy import types as db_types
+ from sqlalchemy.ext.associationproxy import association_proxy
+ from sqlalchemy import Boolean, Column, DateTime, false, Index
+-from sqlalchemy import ForeignKey, Integer
++from sqlalchemy import BigInteger, ForeignKey, Integer
+ from sqlalchemy import schema, String, Text
+ from sqlalchemy import orm
+ from sqlalchemy.orm import declarative_base
+@@ -402,13 +402,13 @@
+     value = Column(Text, nullable=True)
+     attribute_type = Column(String(255), nullable=True)
+     allowable_values = Column(db_types.JsonEncodedList, nullable=True)
+-    lower_bound = Column(Integer, nullable=True)
++    lower_bound = Column(BigInteger, nullable=True)
+     max_length = Column(Integer, nullable=True)
+     min_length = Column(Integer, nullable=True)
+     read_only = Column(Boolean, nullable=True)
+     reset_required = Column(Boolean, nullable=True)
+     unique = Column(Boolean, nullable=True)
+-    upper_bound = Column(Integer, nullable=True)
++    upper_bound = Column(BigInteger, nullable=True)
+ 
+ 
+ class Allocation(Base):
+diff --git a/ironic/tests/unit/db/sqlalchemy/test_migrations.py b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+index 5ff0ef2..187fcfb 100644
+--- a/ironic/tests/unit/db/sqlalchemy/test_migrations.py
++++ b/ironic/tests/unit/db/sqlalchemy/test_migrations.py
+@@ -1490,6 +1490,47 @@
+             )
+             connection.execute(del_stmt)
+ 
++    def _pre_upgrade_9c0446cb6bc3(self, engine):
++        # Create a node to which bios_settings can be added.
++        data = {'uuid': uuidutils.generate_uuid()}
++        nodes = db_utils.get_table(engine, 'nodes')
++        with engine.begin() as connection:
++            insert_node = nodes.insert().values(data)
++            connection.execute(insert_node)
++            node_stmt = sqlalchemy.select(
++                models.Node.id
++            ).where(
++                models.Node.uuid == data['uuid']
++            )
++            node = connection.execute(node_stmt).first()
++            # WARNING: Always copy, never directly return a db object or
++            # piece of a db object. It is a sqlalchemy thing.
++            data['id'] = int(node.id)
++        return data
++
++    def _check_9c0446cb6bc3(self, engine, data):
++        bios_settings = db_utils.get_table(engine, 'bios_settings')
++        node_id = data['id']
++        name = "CbsCmnBoostFmax"
++        # Test max 32-bit unsigned value
++        upper_bound = 4294967295
++        lower_bound = 4294967295
++
++        setting_data = {'node_id': node_id, 'name': name,
++                        'upper_bound': upper_bound, 'lower_bound': lower_bound}
++        with engine.begin() as connection:
++            insert_setting = bios_settings.insert().values(setting_data)
++            connection.execute(insert_setting)
++            bios_setting_stmt = sqlalchemy.select(
++                models.BIOSSetting.upper_bound,
++                models.BIOSSetting.lower_bound
++            ).where(
++                models.BIOSSetting.node_id == node_id
++            )
++            bios_setting = connection.execute(bios_setting_stmt).first()
++            self.assertEqual(upper_bound, bios_setting.upper_bound)
++            self.assertEqual(lower_bound, bios_setting.lower_bound)
++
+     def test_upgrade_and_version(self):
+         with patch_with_engine(self.engine):
+             self.migration_api.upgrade('head')
+diff --git a/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+new file mode 100644
+index 0000000..b0abbdf
+--- /dev/null
++++ b/releasenotes/notes/bug-2095486-f043868726d7f68f.yaml
+@@ -0,0 +1,9 @@
++---
++upgrade:
++  - Change the ``upper_bound`` and ``lower_bound`` columns in the
++    ``bios_settings`` table from Integer to BigInteger to store bigger values.
++fixes:
++  - The ``upper_bound`` and ``lower_bound`` BIOS setting attributes can now be
++    larger integers (up to 32-bit unsigned values as per Redfish standard).
++    Please see `bug 2095486 <https://bugs.launchpad.net/ironic/+bug/2095486>`_
++    for more information.


### PR DESCRIPTION
Set columns in bios_settings table to bigint

Currently the columns upper_bound and lower_bound are set to a signed int, causing issues for systems reporting larger values. The values can be up to 32-bit unsigned as per redfish standard.

This patch will change the data type to BigInteger, which will allow the larger values to be stored.

https://review.opendev.org/c/openstack/ironic/+/968348