### PR TITLE
compare-sbom: handle registry 500 errors with "not found" as missing …

### DIFF
--- a/src/compare-sbom.py
+++ b/src/compare-sbom.py
@@ -241,6 +241,9 @@ def load_sbom_from_container(image_ref: str) -> Optional[Dict]:
         if e.response is not None and e.response.status_code == 404:
             logger.warning(f"Image not found: {image_ref}")
             return None
+        if "not found" in str(e).lower():
+            logger.warning(f"Image not found: {image_ref}")
+            return None
         logger.error(f"Docker API error while pulling image: {e}")
         sys.exit(2)
     except Exception as e:


### PR DESCRIPTION
…image

Some registries return HTTP 500 with "artifact not found" instead of a proper 404 when an image does not exist. Treat API errors containing "not found" in the message as missing images so the comparison is skipped gracefully.

AI-assisted: Claude Code