### PR TITLE
2025.1: update backport-951347.patch

### DIFF
--- a/patches/2025.1/kolla/backport-951347.patch
+++ b/patches/2025.1/kolla/backport-951347.patch
@@ -1,18 +1,6 @@
-From a4f68e18890fdc837230f20c6fcca2972746ab1a Mon Sep 17 00:00:00 2001
-From: Michal Arbet <michal.arbet@ultimum.io>
-Date: Thu, 29 May 2025 23:46:10 +0200
-Subject: [PATCH] Bump proxysql to 3.0.x
-
-This patch bump proxysql 2.7.x to 3.0.x
-
-Change-Id: I30d5093c1997b1ac99a762983248b8d29e677ba3
----
-
-diff --git a/doc/source/contributor/versions.rst b/doc/source/contributor/versions.rst
-index da02236..9de20ec 100644
 --- a/doc/source/contributor/versions.rst
 +++ b/doc/source/contributor/versions.rst
-@@ -42,7 +42,7 @@
+@@ -42,7 +42,7 @@ information about package sources.
  .. _`Kibana install guide`: https://www.elastic.co/guide/en/kibana/7.10/install.html
  .. _`Logstash install guide`: https://www.elastic.co/guide/en/logstash/7.9/installing-logstash.html
  .. _`TreasureData install guide`: https://www.fluentd.org/download
@@ -21,26 +9,22 @@ index da02236..9de20ec 100644
  
  .. _`Team RabbitMQ 'Cloudsmith' repo (Deb)`: https://www.rabbitmq.com/install-debian.html#apt-cloudsmith
  .. _`Team RabbitMQ 'Modern Erlang' PPA`: https://launchpad.net/~rabbitmq/+archive/ubuntu/rabbitmq-erlang
-diff --git a/docker/base/Dockerfile.j2 b/docker/base/Dockerfile.j2
-index 2af0243..5765ee8 100644
 --- a/docker/base/Dockerfile.j2
 +++ b/docker/base/Dockerfile.j2
-@@ -309,7 +309,7 @@
-    {'name': 'influxdb', 'url': 'https://repos.influxdata.com/influxdata-archive_compat.key'},
+@@ -325,7 +325,7 @@ COPY apt_preferences /etc/apt/preferences.d/kolla-custom
+    {'name': 'influxdb', 'url': 'https://repos.influxdata.com/influxdata-archive.key'},
     {'name': 'mariadb', 'url': 'https://downloads.mariadb.com/MariaDB/mariadb-keyring-2019.gpg', 'type': 'gpg'},
     {'name': 'opensearch', 'url': 'https://artifacts.opensearch.org/publickeys/opensearch.pgp'},
 -   {'name': 'proxysql', 'url': 'https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/repo_pub_key'},
 +   {'name': 'proxysql', 'url': 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key'},
+    {'name': 'proxysql-3', 'url': 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key'},
     {'name': 'treasuredata', 'url': 'https://packages.treasuredata.com/GPG-KEY-td-agent'},
  ] %}
- 
-diff --git a/docker/base/proxysql.repo b/docker/base/proxysql.repo
-index 1d45963e0..a9069ffb5 100644
 --- a/docker/base/proxysql.repo
 +++ b/docker/base/proxysql.repo
 @@ -1,7 +1,7 @@
  [proxysql]
- name = ProxySQL
+ name = ProxySQL 2.7.x
  # NOTE(mnasiadka): use 9 for both 9 and 10
 -baseurl = https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/almalinux/9
 -gpgkey = https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/repo_pub_key
@@ -48,11 +32,9 @@ index 1d45963e0..a9069ffb5 100644
 +gpgkey = https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
  gpgcheck = 1
  enabled = 0
-diff --git a/kolla/template/repos.yaml b/kolla/template/repos.yaml
-index 907909e..6b66aec 100644
 --- a/kolla/template/repos.yaml
 +++ b/kolla/template/repos.yaml
-@@ -82,7 +82,7 @@
+@@ -90,7 +90,7 @@ debian:
      component: "main"
      gpg_key: "opensearch.asc"
    proxysql:
@@ -61,7 +43,7 @@ index 907909e..6b66aec 100644
      suite: "./"
      component: ""
      gpg_key: "proxysql.asc"
-@@ -134,7 +134,7 @@
+@@ -152,7 +152,7 @@ debian-aarch64:
      component: "main"
      gpg_key: "opensearch.asc"
    proxysql:
@@ -70,7 +52,7 @@ index 907909e..6b66aec 100644
      suite: "./"
      component: ""
      gpg_key: "proxysql.asc"
-@@ -228,7 +228,7 @@
+@@ -259,7 +259,7 @@ ubuntu:
      component: "main"
      gpg_key: "opensearch.asc"
    proxysql:
@@ -79,7 +61,7 @@ index 907909e..6b66aec 100644
      suite: "./"
      component: ""
      gpg_key: "proxysql.asc"
-@@ -281,7 +281,7 @@
+@@ -322,7 +322,7 @@ ubuntu-aarch64:
      component: "main"
      gpg_key: "opensearch.asc"
    proxysql:
@@ -88,12 +70,3 @@ index 907909e..6b66aec 100644
      suite: "./"
      component: ""
      gpg_key: "proxysql.asc"
-diff --git a/releasenotes/notes/bump-proxysql-version-5669b13bcc3d88fe.yaml b/releasenotes/notes/bump-proxysql-version-5669b13bcc3d88fe.yaml
-new file mode 100644
-index 0000000..791e41d
---- /dev/null
-+++ b/releasenotes/notes/bump-proxysql-version-5669b13bcc3d88fe.yaml
-@@ -0,0 +1,3 @@
-+---
-+upgrade:
-+  - Upgraded ProxySQL to version ``3.0.x``.


### PR DESCRIPTION
Required because of
https://review.opendev.org/c/openstack/kolla/+/974429.