### PR TITLE
2024.2: refresh keystonemiddleware.patch context

### DIFF
--- a/patches/2024.2/openstack_requirements/keystonemiddleware.patch
+++ b/patches/2024.2/openstack_requirements/keystonemiddleware.patch
@@ -1,15 +1,15 @@
 --- a/upper-constraints.txt
 +++ b/upper-constraints.txt
-@@ -368,7 +368,7 @@ infi.dtypes.iqn===0.4.0
+@@ -368,7 +368,7 @@
  XStatic-tv4===1.2.7.0
  XStatic-JSEncrypt===2.3.1.1
  python-cinderclient===9.6.0
--keystonemiddleware===10.7.1
+-keystonemiddleware===10.7.2
 +keystonemiddleware===10.12.1
  django-formtools===2.5.1
  XStatic-Spin===1.2.5.3
  tap-as-a-service===14.0.0.0rc1
-@@ -386,7 +386,7 @@ sushy===5.2.1
+@@ -386,7 +386,7 @@
  python-neutronclient===11.3.1
  types-setuptools===73.0.0.20240822
  pika===1.3.2


### PR DESCRIPTION
## Summary

The `requirements-stable-2024.2` tarball was updated upstream:
`keystonemiddleware` moved from `10.7.1` to `10.7.2`, shifting the
patch context so `patches/2024.2/openstack_requirements/keystonemiddleware.patch`
failed with _"Hunk #1 FAILED at 368"_. The `sushy` context line in
hunk #2 also changed (`5.2.1` → `5.2.2`).

The pinned target versions are unchanged — `keystonemiddleware` is
still bumped to `10.12.1` and `oslo.cache` to `3.11.0`. Only the
source-side context is updated to match the current upstream file.

Identical fix to #719 ("2025.1: refresh keystonemiddleware.patch
context") applied to the 2024.2 branch.

## Test plan

- [ ] Patch verified to apply cleanly against `requirements-stable-2024.2.tar.gz` as downloaded on 2026-04-28
- [ ] `container-images-kolla-push-2024.2` CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)