### PR TITLE
Pin MariaDB to pre-MDEV-39685 versions

### DIFF
--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,3 +5,7 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:10.11.16*
+Pin-Priority: 1001

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,3 +9,7 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:10.11.16*
+Pin-Priority: 1001

--- a/templates/2025.2/apt_preferences.ubuntu.j2
+++ b/templates/2025.2/apt_preferences.ubuntu.j2
@@ -9,3 +9,7 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:11.4.10*
+Pin-Priority: 1001


### PR DESCRIPTION
## Summary

- Pin `mariadb-* libmariadb* mysql-common` to `1:10.11.16*` in the 2024.2 and 2025.1 templates
- Pin the same family to `1:11.4.10*` in the 2025.2 template
- Blocks [MDEV-39685](https://jira.mariadb.org/browse/MDEV-39685) (Galera multi-table UPDATE SIGSEGV in `mysql_multi_update`) until 10.11.18 / 11.4.12 ship

**Depends on #726 (zuul: retire 2024.2) being merged first.**

## Background

MariaDB 10.11.17 (released 2026-05-18) introduced a crash in `mysql_multi_update` tracked as [MDEV-39685](https://jira.mariadb.org/browse/MDEV-39685) ("Galera multi table update crash", filed 2026-05-20, fixed 2026-05-22). The crash fires deterministically during every fresh Octavia deployment (migration `e37941b010db` issues a LEFT JOIN UPDATE against empty tables). Under concurrent Tempest load the repeated crashes exhaust the ProxySQL connection pool (error 9001), taking down Cinder and Keystone and failing 60–70% of the Tempest suite. This has been confirmed on 10.11.17.

MDEV-39685 lists 11.4.12 and 11.8.8 as fix versions, meaning the offending commit is present in 11.4.10+ and 11.8.x. However, at least one report in the ticket notes the issue could not be reproduced on 11.4. The 2025.2 pin to `1:11.4.10*` is therefore precautionary — remove it first if it causes problems, as the impact on 11.4 is unconfirmed.

The broad `libmariadb*` selector is intentional: all three `template-overrides.mako` files install `libmariadb-dev-compat` explicitly, which would otherwise pull in an unpinned `libmariadb-dev` → `libmariadb3` dependency chain and produce a mixed-version install.

## Removal

Remove this pin once 10.11.18 / 11.4.12 have entered the dlm.mariadb.com apt repo and a nightly kolla build can pick them up.