### PR TITLE
zuul: retire 2024.2

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -62,10 +62,6 @@
     max: 1
 
 - semaphore:
-    name: semaphore-container-images-kolla-push-2024.2
-    max: 1
-
-- semaphore:
     name: semaphore-container-images-kolla-push-2025.1
     max: 1
 
@@ -106,20 +102,6 @@
       push_images: false
 
 - job:
-    name: container-images-kolla-patch-2024.2
-    parent: container-images-kolla-patch
-    vars:
-      version_openstack: "2024.2"
-      push_images: false
-
-- job:
-    name: container-images-kolla-build-2024.2
-    parent: container-images-kolla-build
-    vars:
-      version_openstack: "2024.2"
-      push_images: false
-
-- job:
     name: container-images-kolla-patch-2025.1
     parent: container-images-kolla-patch
     vars:
@@ -154,19 +136,6 @@
       - name: semaphore-container-images-kolla-push-2024.1
     vars:
       version_openstack: "2024.1"
-      push_images: true
-    secrets:
-      - name: secret
-        secret: SECRET_CONTAINER_IMAGES_KOLLA
-        pass-to-parent: true
-
-- job:
-    name: container-images-kolla-push-2024.2
-    parent: container-images-kolla-build
-    semaphores:
-      - name: semaphore-container-images-kolla-push-2024.2
-    vars:
-      version_openstack: "2024.2"
       push_images: true
     secrets:
       - name: secret
@@ -218,13 +187,11 @@
         - python-black
         - yamllint
         - container-images-kolla-patch-2024.1
-        - container-images-kolla-patch-2024.2
         - container-images-kolla-patch-2025.1
         - container-images-kolla-patch-2025.2
     label:
       jobs:
         - container-images-kolla-build-2024.1
-        - container-images-kolla-build-2024.2
         - container-images-kolla-build-2025.1
         - container-images-kolla-build-2025.2
     periodic-daily:
@@ -235,14 +202,11 @@
     periodic-midnight:
       jobs:
         - container-images-kolla-push-2024.1
-        - container-images-kolla-push-2024.2
         - container-images-kolla-push-2025.1
         - container-images-kolla-push-2025.2
     post:
       jobs:
         - container-images-kolla-push-2024.1:
-            branches: main
-        - container-images-kolla-push-2024.2:
             branches: main
         - container-images-kolla-push-2025.1:
             branches: main

--- a/Giltfile.yaml
+++ b/Giltfile.yaml
@@ -10,10 +10,3 @@ repositories:
         dstFile: overlays/2024.1/cinder/source/cinder/volume/drivers
     commands:
       - cmd: black overlays/2024.1/cinder/source/cinder/volume/drivers
-  - git: https://github.com/LINBIT/openstack-cinder
-    version: 'linstor/stable/2024.2'
-    sources:
-      - src: cinder/volume/drivers/linstordrv.py
-        dstFile: overlays/2024.2/cinder/source/cinder/volume/drivers
-    commands:
-      - cmd: black overlays/2024.2/cinder/source/cinder/volume/drivers

--- a/scripts/001-prepare.sh
+++ b/scripts/001-prepare.sh
@@ -52,8 +52,6 @@ pushd $PROJECT_REPOSITORY_PATH > /dev/null
 if [[ "$OPENSTACK_VERSION" != "latest" ]]; then
     if [[ "$OPENSTACK_VERSION" == "2024.1" ]]; then
         git checkout origin/unmaintained/$OPENSTACK_VERSION
-    elif [[ "$OPENSTACK_VERSION" == "2024.2" ]]; then
-        git checkout 2024.2-eol
     else
         git checkout origin/stable/$OPENSTACK_VERSION
     fi

--- a/scripts/004-build.sh
+++ b/scripts/004-build.sh
@@ -47,7 +47,7 @@ else
     fi
 fi
 
-if [[ "$OPENSTACK_VERSION" == "2024.1" || "$OPENSTACK_VERSION" == "2024.2" || "$OPENSTACK_VERSION" == "2025.1" ]]; then
+if [[ "$OPENSTACK_VERSION" == "2024.1" || "$OPENSTACK_VERSION" == "2025.1" ]]; then
     PLATFORM_OPTS="--platform $PLATFORM"
 fi
 

--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -95,7 +95,7 @@ for image in client.images.list(filters=FILTERS):
             logger.error(f"Configuration for {name} ({best_key}) not found")
             continue
 
-        if best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
+        if best_key == "ovn" and OPENSTACK_VERSION in ["2024.1"]:
             command = "ovn-controller --version"
         else:
             command = configuration[best_key]
@@ -143,7 +143,7 @@ for image in client.images.list(filters=FILTERS):
                 # lego version 4.20.4 linux/amd64
                 r = findall(r"lego version (.*) linux", result)
 
-            elif best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
+            elif best_key == "ovn" and OPENSTACK_VERSION in ["2024.1"]:
                 # ovn-controller 22.03.0
                 r = findall(r"ovn-controller (.*)\n", result)
 


### PR DESCRIPTION
Closes https://github.com/osism/issues/issues/1367

## Summary

- Upstream `openstack/kolla` dropped `stable/2024.2` without moving it to `unmaintained/`, causing `container-images-kolla-patch-2024.2` to fail consistently
- Removes all 2024.2 Zuul job definitions, semaphores, and pipeline entries following the same pattern used for the 2023.2 retirement
- Also removes the `linstor/stable/2024.2` Giltfile entry and version-specific conditions in build scripts
- Reverts the `2024.2-eol` checkout added in #728 (`fffca2d`) in `scripts/001-prepare.sh`. That `elif` existed only to keep the now-removed 2024.2 job working; with the job gone it is dead code
- Build artifacts (`defaults/`, `overlays/`, `patches/`, `templates/`, `release/`) are kept in place

## Test plan

- [ ] Verify `container-images-kolla-patch-2024.1`, `2025.1`, and `2025.2` still pass in the check pipeline
- [ ] Confirm no 2024.2 jobs appear in Zuul after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)