### PR TITLE
Retire OpenStack 2024.2 Dalmatian

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -62,15 +62,7 @@
     max: 1
 
 - semaphore:
-    name: semaphore-container-images-kolla-push-2024.2
-    max: 1
-
-- semaphore:
     name: semaphore-container-images-kolla-push-2025.1
-    max: 1
-
-- semaphore:
-    name: semaphore-container-images-kolla-push-2024.2-aarch64
     max: 1
 
 - job:
@@ -116,20 +108,6 @@
       push_images: false
 
 - job:
-    name: container-images-kolla-patch-2024.2
-    parent: container-images-kolla-patch
-    vars:
-      version_openstack: "2024.2"
-      push_images: false
-
-- job:
-    name: container-images-kolla-build-2024.2
-    parent: container-images-kolla-build
-    vars:
-      version_openstack: "2024.2"
-      push_images: false
-
-- job:
     name: container-images-kolla-patch-2025.1
     parent: container-images-kolla-patch
     vars:
@@ -158,32 +136,12 @@
       push_images: false
 
 - job:
-    name: container-images-kolla-build-2024.2-aarch64
-    parent: container-images-kolla-build-aarch64
-    vars:
-      version_openstack: "2024.2"
-      push_images: false
-
-- job:
     name: container-images-kolla-push-2024.1
     parent: container-images-kolla-build
     semaphores:
       - name: semaphore-container-images-kolla-push-2024.1
     vars:
       version_openstack: "2024.1"
-      push_images: true
-    secrets:
-      - name: secret
-        secret: SECRET_CONTAINER_IMAGES_KOLLA
-        pass-to-parent: true
-
-- job:
-    name: container-images-kolla-push-2024.2
-    parent: container-images-kolla-build
-    semaphores:
-      - name: semaphore-container-images-kolla-push-2024.2
-    vars:
-      version_openstack: "2024.2"
       push_images: true
     secrets:
       - name: secret
@@ -217,19 +175,6 @@
         pass-to-parent: true
 
 - job:
-    name: container-images-kolla-push-2024.2-aarch64
-    parent: container-images-kolla-build-aarch64
-    semaphores:
-      - name: semaphore-container-images-kolla-push-2024.2-aarch64
-    vars:
-      version_openstack: "2024.2"
-      push_images: true
-    secrets:
-      - name: secret
-        secret: SECRET_CONTAINER_IMAGES_KOLLA
-        pass-to-parent: true
-
-- job:
     name: container-images-kolla-release
     parent: container-images-kolla-build
     vars:
@@ -248,16 +193,13 @@
         - python-black
         - yamllint
         - container-images-kolla-patch-2024.1
-        - container-images-kolla-patch-2024.2
         - container-images-kolla-patch-2025.1
         - container-images-kolla-patch-2025.2
     label:
       jobs:
         - container-images-kolla-build-2024.1
-        - container-images-kolla-build-2024.2
         - container-images-kolla-build-2025.1
         - container-images-kolla-build-2025.2
-        # - container-images-kolla-build-2024.2-aarch64
     periodic-daily:
       jobs:
         - flake8
@@ -266,22 +208,16 @@
     periodic-midnight:
       jobs:
         - container-images-kolla-push-2024.1
-        - container-images-kolla-push-2024.2
         - container-images-kolla-push-2025.1
         - container-images-kolla-push-2025.2
-        # - container-images-kolla-push-2024.2-aarch64
     post:
       jobs:
         - container-images-kolla-push-2024.1:
-            branches: main
-        - container-images-kolla-push-2024.2:
             branches: main
         - container-images-kolla-push-2025.1:
             branches: main
         - container-images-kolla-push-2025.2:
             branches: main
-        # - container-images-kolla-push-2024.2-aarch64:
-        #     branches: main
     tag:
       jobs:
         - container-images-kolla-release

--- a/Giltfile.yaml
+++ b/Giltfile.yaml
@@ -10,10 +10,3 @@ repositories:
         dstFile: overlays/2024.1/cinder/source/cinder/volume/drivers
     commands:
       - cmd: black overlays/2024.1/cinder/source/cinder/volume/drivers
-  - git: https://github.com/LINBIT/openstack-cinder
-    version: 'linstor/stable/2024.2'
-    sources:
-      - src: cinder/volume/drivers/linstordrv.py
-        dstFile: overlays/2024.2/cinder/source/cinder/volume/drivers
-    commands:
-      - cmd: black overlays/2024.2/cinder/source/cinder/volume/drivers

--- a/scripts/004-build.sh
+++ b/scripts/004-build.sh
@@ -47,7 +47,7 @@ else
     fi
 fi
 
-if [[ "$OPENSTACK_VERSION" == "2024.1" || "$OPENSTACK_VERSION" == "2024.2" || "$OPENSTACK_VERSION" == "2025.1" ]]; then
+if [[ "$OPENSTACK_VERSION" == "2024.1" || "$OPENSTACK_VERSION" == "2025.1" ]]; then
     PLATFORM_OPTS="--platform $PLATFORM"
 fi
 

--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -95,7 +95,7 @@ for image in client.images.list(filters=FILTERS):
             logger.error(f"Configuration for {name} ({best_key}) not found")
             continue
 
-        if best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
+        if best_key == "ovn" and OPENSTACK_VERSION in ["2024.1"]:
             command = "ovn-controller --version"
         else:
             command = configuration[best_key]
@@ -143,7 +143,7 @@ for image in client.images.list(filters=FILTERS):
                 # lego version 4.20.4 linux/amd64
                 r = findall(r"lego version (.*) linux", result)
 
-            elif best_key == "ovn" and OPENSTACK_VERSION in ["2024.1", "2024.2"]:
+            elif best_key == "ovn" and OPENSTACK_VERSION in ["2024.1"]:
                 # ovn-controller 22.03.0
                 r = findall(r"ovn-controller (.*)\n", result)
 

--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,3 +5,7 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:10.11.16*
+Pin-Priority: 1001

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,3 +9,7 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:10.11.16*
+Pin-Priority: 1001

--- a/templates/2025.2/apt_preferences.ubuntu.j2
+++ b/templates/2025.2/apt_preferences.ubuntu.j2
@@ -9,3 +9,7 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+Package: mariadb-* libmariadb* mysql-common
+Pin: version 1:11.4.10*
+Pin-Priority: 1001


### PR DESCRIPTION
## Summary

OpenStack 2024.2 Dalmatian is a non-SLURP release that reached its
end-of-life deadline on 2026-04-29. The upstream kolla `stable/2024.2`
branch has been deleted (unlike 2024.1, which moved to
`unmaintained/2024.1`), causing the
`container-images-kolla-patch-2024.2` CI job to fail consistently.

Remove all 2024.2 Zuul jobs and pipeline entries:
- Zuul job definitions: patch, build, build-aarch64, push, push-aarch64
- Semaphores for the above jobs
- 2024.2 entries from all pipeline sections
- `linstor/stable/2024.2` from `Giltfile.yaml` (gilt runs all entries
  at once and that branch has also disappeared from the LINBIT repo)
- `"2024.2"` from version-specific conditions in
  `scripts/004-build.sh` and `src/tag-images-with-the-version.py`

Build artifacts (`defaults/`, `overlays/`, `patches/`, `templates/`,
`release/`) are kept in place, consistent with how older retired
versions are preserved in the repository.

Tracks: https://github.com/osism/issues/issues/1367