### PR TITLE
keystone: constrain keycloak-backend install

### DIFF
--- a/templates/2023.2/template-overrides.mako
+++ b/templates/2023.2/template-overrides.mako
@@ -100,7 +100,7 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}

--- a/templates/2024.1/template-overrides.mako
+++ b/templates/2024.1/template-overrides.mako
@@ -98,7 +98,7 @@ RUN apt-get update ${"\\"}
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}

--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -92,7 +92,7 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -90,7 +90,7 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}

--- a/templates/2025.2/template-overrides.mako
+++ b/templates/2025.2/template-overrides.mako
@@ -90,7 +90,7 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libapache2-mod-auth-openidc ${"\\"}

--- a/templates/2026.1/template-overrides.mako
+++ b/templates/2026.1/template-overrides.mako
@@ -90,7 +90,7 @@ RUN curl -o /tmp/kolla-operations.tar.gz https://github.com/osism/kolla-operatio
 {% endblock %}
 
 {% block keystone_footer %}
-RUN python3 -m pip --no-cache-dir install keystone-keycloak-backend
+RUN python3 -m pip --no-cache-dir install -c /requirements/upper-constraints.txt keystone-keycloak-backend
 RUN apt-get update ${"\\"}
     && apt-get -y install --no-install-recommends ${"\\"}
            libldap-common ${"\\"}


### PR DESCRIPTION
## Where this is

`templates/<release>/template-overrides.mako` is this repo's kolla
template-override source: `scripts/001-prepare.sh` renders it into
`templates/$OPENSTACK_VERSION/template-overrides.j2`, and
`scripts/004-build.sh` hands that to `kolla-build` via `--template-override`.
Each `{% block %}` in it fills a matching empty extension point in kolla's
generated Dockerfiles — in this case
`kolla/docker/keystone/keystone/Dockerfile.j2:46`, which is just
`{% block keystone_footer %}{% endblock %}`.

So the line changed here becomes a `RUN` step in the **final `keystone`
image**, running after keystone itself has been installed into
`/var/lib/kolla/venv` — the very venv keystone executes from. It installs
`keystone-keycloak-backend` without passing the OpenStack constraints file, so
a transitive dependency of that one plugin is free to overwrite a package the
release has already pinned *for keystone*.

On 2026-08-26 that is what happened, and it broke the testbed `current` and
`next` nutshell lanes.

## What went wrong

`jwcrypto` 1.5.9 was published at 2026-08-26T12:54:08Z, raising its
`cryptography` floor from `>=39.0.0` to `>=49.0.0`. Because the install is
unconstrained, pip uninstalled the pinned cryptography 43.0.3 and installed
50.0.1 in its place. pip reported the conflict:

```
pyopenssl 24.2.1 requires cryptography<44,>=41.0.5, but you have
cryptography 50.0.1 which is incompatible.
```

A conflict report is not an exit code, so the image was pushed anyway.
Keystone's startup path then failed during import, because pyOpenSSL 24.2.1
references a binding cryptography 50 no longer exposes:

```
File ".../OpenSSL/crypto.py", line 876, in X509Extension
    _lib.GEN_EMAIL: "email",
AttributeError: module 'lib' has no attribute 'GEN_EMAIL'
```

`keystone-manage db_sync` aborted, keystone never bootstrapped, and every
dependent service registration failed with HTTP 503 against the identity
endpoint. Both lanes then timed out at 4h31m rather than failing fast, because
the nutshell chain does not abort on a permanent play failure — a separate,
pre-existing issue.

Affected builds, `container-images-kolla-push-2025.1`:

| build | when | jwcrypto | cryptography |
|-------|------|----------|--------------|
| [`74787d9e`](https://zuul.services.osism.tech/t/osism/build/74787d9eada84134b261848e1fa4b013) | 08-25 17:09 | 1.5.8 | 43.0.3 — OK |
| [`fe65ae94`](https://zuul.services.osism.tech/t/osism/build/fe65ae94b6354c8c92563d3005fe81cf) | 08-26 00:01 | 1.5.8 | 43.0.3 — OK |
| [`686732f7`](https://zuul.services.osism.tech/t/osism/build/686732f7f2a7451eb7f200e2b8b1b53c) | 08-26 12:56 | 1.5.9 | **50.0.1 — broken** |
| [`8ef6f0dd`](https://zuul.services.osism.tech/t/osism/build/8ef6f0dd4d634e699e4417d15852ef90) | 08-27 00:01 | 1.5.9 | **50.0.1 — broken** |

The resulting deploy failures:
[`7e89e00b`](https://zuul.services.osism.tech/t/osism/build/7e89e00ba83d48b79d9df204cb1cbd2e)
(current) and
[`3b6c5232`](https://zuul.services.osism.tech/t/osism/build/3b6c5232a767498e9bd2345d8a164087)
(next).

The `stable` lane passed only because it consumes a release-pinned tag
(`keystone:27.0.3.20260814`, built 08-14), not the floating one.

## The change

Adds `-c /requirements/upper-constraints.txt` to that one `RUN`, matching the
constrained install already used earlier in the same image for
`requests-kerberos`. One line in each of the six release templates.

## Verification

`pip install --dry-run` (pip 26.2.1, `--python-version 3.12`,
`--only-binary=:all:`) against the `stable/2025.1` constraints:

| | cryptography | jwcrypto | keystone-keycloak-backend | python-keycloak |
|---|---|---|---|---|
| unconstrained | 50.0.1 | 1.5.9 | 0.5.0 | 3.12.0 |
| with `-c` | **43.0.3** | **1.5.6** | 0.5.0 | 3.12.0 |

The constrained resolution lands on the release-pinned pair and leaves the
keycloak backend version unchanged; the unconstrained one reproduces the broken
image. `jwcrypto===1.5.6` is itself pinned in upper-constraints and satisfies
`python-keycloak`'s `>=1.5.4,<2.0.0`, so this is a pin rather than resolver
backtracking.

The runtime failure also reproduces standalone: in a bare venv,
`pip install pyOpenSSL==24.2.1` leaves cryptography 43.0.3 and
`from OpenSSL import SSL` works; a *separate* `pip install cryptography==50.0.1`
then produces the identical `crypto.py` line 876 `GEN_EMAIL` traceback. Note pip
rejects that pair outright when both are named in one command, so only the
separate-step Dockerfile shape can reach the broken state.

**Not yet verified:** an actual image build. Resolution was exercised outside
the image, so this is draft until CI has built keystone. `upper-constraints`
does not cover `keystone-keycloak-backend` itself, so its dependencies are
constrained but the package is not, and it is not runtime-tested against that
triple by anyone upstream.

## Scope notes

- Applied to all six templates. Affected images were confirmed for 2024.1,
  2024.2, 2025.1, 2025.2 and 2026.1; 2023.2 carries the same line but has no
  build job at present, and is changed for consistency.
- Two other unconstrained pip installs remain in these templates —
  `horizon_header` (`setuptools`, `mysqlclient`) and the global-footer
  `pyclean`. Neither is implicated here and both are left untouched;
  constraining `setuptools` in particular deserves its own change.
- Using kolla's `macros.install_pip` would be more idiomatic but adds
  `--upgrade` semantics, which seemed the wrong direction for a bug about pip
  being too eager. Happy to switch if maintainers prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
