### PR TITLE
keystone: Add backport for CVE patch

### DIFF
--- a/patches/2024.1/keystone/0005-trusts-oauth1-app-creds-reject-delegated-tokens-acro.patch
+++ b/patches/2024.1/keystone/0005-trusts-oauth1-app-creds-reject-delegated-tokens-acro.patch
@@ -1,7 +1,7 @@
-From 90d44890ec63a144b975254fc98f44d569009ea4 Mon Sep 17 00:00:00 2001
+From 1adf1f098ff52abf5cf5bce12e6afc1322cbaa68 Mon Sep 17 00:00:00 2001
 From: Grzegorz Grasza <xek@redhat.com>
 Date: Thu, 23 Jul 2026 09:32:00 +0200
-Subject: [PATCH 5/6] trusts, oauth1, app-creds: reject delegated tokens across
+Subject: [PATCH 5/7] trusts, oauth1, app-creds: reject delegated tokens across
  all endpoints
 
 _check_application_credential() in trusts.py only recognized

--- a/patches/2024.1/keystone/0006-auth-reject-delegated-tokens-from-token-method-reaut.patch
+++ b/patches/2024.1/keystone/0006-auth-reject-delegated-tokens-from-token-method-reaut.patch
@@ -1,7 +1,7 @@
-From 8ee435054a4e4c6b65e82e27c4ba78dc58ff3538 Mon Sep 17 00:00:00 2001
+From 57407461384ee01a86adec6aabdd32240b009a09 Mon Sep 17 00:00:00 2001
 From: Grzegorz Grasza <xek@redhat.com>
 Date: Mon, 24 Aug 2026 13:13:51 +0200
-Subject: [PATCH 6/6] auth: reject delegated tokens from token-method
+Subject: [PATCH 6/7] auth: reject delegated tokens from token-method
  reauthentication
 
 token_authenticate() unconditionally blocks trust-scoped and

--- a/patches/2024.1/keystone/0007-Ban-ec2credential-tokens-from-Keystone-API.patch
+++ b/patches/2024.1/keystone/0007-Ban-ec2credential-tokens-from-Keystone-API.patch
@@ -1,0 +1,250 @@
+From ef7b417f0f7b06a1095501929018d8a92c05bf68 Mon Sep 17 00:00:00 2001
+From: Artem Goncharov <artem.goncharov@gmail.com>
+Date: Wed, 15 Jul 2026 13:08:10 +0200
+Subject: [PATCH 7/7] Ban ec2credential tokens from Keystone API
+
+EC2 credentials are supported by Keystone only to allow Swift to
+implement S3 protocol while using Keystone identities. There are no real
+reasons for ec2credential fernet tokens (after authenticating) being
+accepted by the Keystone itself. There are many barriers where
+Keystone explicitly checks and bans such credentials to prevent
+rescoping or accessing resources belonging to other projects. There
+have been multiple security issues due to missing guards. Instead of
+those individual barriers, simply bar such tokens from any Keystone
+operation except validating the token (which Swift needs to do) and
+re-authenticating (renewing the token). The latter is questionable on
+its own, but is kept for now.
+
+Solve the problem by simply rejecting the ec2credential issued token
+in the auth middleware which runs before any authenticated request.
+The /auth/tokens are unauthenticated and as such are not affected.
+
+Add a config option, [auth] ban_ec2credential_tokens, default True, so
+deployments with an undocumented dependency on using EC2-derived
+tokens directly against the API can opt out instead of being broken
+outright. Also add a release note, since this changes existing,
+documented API behavior for anyone relying on it.
+
+Change-Id: I4dd5817d20394369cfadd20ccf476a0660760c52
+Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
+(cherry picked from commit 910ebab06db3b9c119a3139b9443f7bd2369158f)
+Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
+Signed-off-by: Grzegorz Grasza <xek@redhat.com>
+(cherry picked from commit 9297efeb7ed0cc82ce67418b697e9645492f94d8)
+---
+ keystone/conf/auth.py                         |  17 +++
+ .../middleware/auth_context.py                |  10 ++
+ keystone/tests/unit/test_contrib_ec2_core.py  | 120 ++++++++++++++++++
+ ...tial-tokens-backport-9f3c7a1b2d4e5f6a.yaml |  16 +++
+ 4 files changed, 163 insertions(+)
+ create mode 100644 releasenotes/notes/ban-ec2credential-tokens-backport-9f3c7a1b2d4e5f6a.yaml
+
+diff --git a/keystone/conf/auth.py b/keystone/conf/auth.py
+index 312f31c5a..395f5611c 100644
+--- a/keystone/conf/auth.py
++++ b/keystone/conf/auth.py
+@@ -105,6 +105,22 @@ rejected from those actions by default.
+     ),
+ )
+ 
++ban_ec2credential_tokens = cfg.BoolOpt(
++    'ban_ec2credential_tokens',
++    default=True,
++    help=utils.fmt(
++        """
++EC2 credentials are supported by keystone only to allow Swift to implement
++the S3 protocol against keystone identities. When enabled (the default), a
++token issued via EC2 credential authentication (ec2credential) is rejected
++by the auth middleware for every keystone API operation except validating
++the token, which Swift's S3 support needs. Disable only if a deployment
++has an existing, legitimate dependency on using EC2-derived tokens
++directly against the keystone API.
++"""
++    ),
++)
++
+ 
+ GROUP_NAME = __name__.split('.')[-1]
+ ALL_OPTS = [
+@@ -116,6 +132,7 @@ ALL_OPTS = [
+     mapped,
+     application_credential,
+     additional_primary_auth_methods,
++    ban_ec2credential_tokens,
+ ]
+ 
+ 
+diff --git a/keystone/server/flask/request_processing/middleware/auth_context.py b/keystone/server/flask/request_processing/middleware/auth_context.py
+index 3d7c2abb2..3400e2c24 100644
+--- a/keystone/server/flask/request_processing/middleware/auth_context.py
++++ b/keystone/server/flask/request_processing/middleware/auth_context.py
+@@ -433,6 +433,16 @@ class AuthContextMiddleware(provider_api.ProviderAPIMixin,
+                 'token': self.token
+             }
+             auth_context.update(additional)
++            if (
++                CONF.auth.ban_ec2credential_tokens
++                and 'ec2credential' in self.token.methods
++            ):
++                raise exception.Forbidden(
++                    _(
++                        'EC2 credential tokens cannot be used for '
++                        'authorization.'
++                    )
++                )
+ 
+         elif self._validate_trusted_issuer(request):
+             auth_context = self._build_tokenless_auth_context(request)
+diff --git a/keystone/tests/unit/test_contrib_ec2_core.py b/keystone/tests/unit/test_contrib_ec2_core.py
+index f1f3058f3..b237bfdf7 100644
+--- a/keystone/tests/unit/test_contrib_ec2_core.py
++++ b/keystone/tests/unit/test_contrib_ec2_core.py
+@@ -241,3 +241,123 @@ class EC2ContribCoreV3(test_v3.RestfulTestCase):
+             '/ec2tokens',
+             body={'credentials': credentials},
+             expected_status=http.client.UNAUTHORIZED)
++
++    def test_valid_ec2_token_invalid_for_regular_endpoints(self, **kwargs):
++        signer = ec2_utils.Ec2Signer(self.cred_blob['secret'])
++        timestamp = utils.isotime(timeutils.utcnow())
++        credentials = {
++            'access': self.cred_blob['access'],
++            'secret': self.cred_blob['secret'],
++            'host': 'localhost',
++            'verb': 'GET',
++            'path': '/',
++            'params': {
++                'SignatureVersion': '2',
++                'Action': 'Test',
++                'Timestamp': timestamp,
++            },
++        }
++        credentials['signature'] = signer.generate(credentials)
++        # Authenticate as system admin by default unless overridden via kwargs
++        token = None
++        if 'noauth' in kwargs and kwargs['noauth']:
++            token = None
++        else:
++            PROVIDERS.assignment_api.create_system_grant_for_user(
++                self.user_id, self.role_id
++            )
++            token = self.get_system_scoped_token()
++
++        resp = self.post(
++            '/ec2tokens',
++            body={'credentials': credentials},
++            expected_status=http.client.OK,
++            token=token,
++            noauth=kwargs.get('noauth'),
++        )
++        self.assertValidProjectScopedTokenResponse(resp, self.user)
++
++        # Extract the EC2 credential token from the response - the password
++        # token used for POST /ec2tokens is NOT the EC2 token.
++        ec2_token = resp.headers['X-Subject-Token']
++        self.assertEqual(['ec2credential'], resp.json['token']['methods'])
++
++        # The EC2 token should be rejected by regular endpoints (check subset
++        # the user should normally be able to query).
++        self.get(
++            '/users', token=ec2_token, expected_status=http.client.FORBIDDEN
++        )
++        self.get(
++            f"/users/{self.user_id}",
++            token=ec2_token,
++            expected_status=http.client.FORBIDDEN,
++        )
++        self.get(
++            '/auth/projects',
++            token=ec2_token,
++            expected_status=http.client.FORBIDDEN,
++        )
++
++        # The EC2 token should be still validated.
++        self.get(
++            '/auth/tokens',
++            headers={"X-Subject-Token": ec2_token},
++            token=token,
++            expected_status=http.client.OK,
++        )
++        # Test reauth via the token method is rejected for EC2 credentialed
++        # tokens since they are delegated and must not be exchanged for another
++        # token with a different scope.
++        self.post(
++            '/auth/tokens',
++            headers={"X-Subject-Token": ec2_token},
++            body={
++                "auth": {
++                    "identity": {
++                        "methods": ["token"],
++                        "token": {"id": ec2_token},
++                    }
++                }
++            },
++            token=token,
++            expected_status=http.client.FORBIDDEN,
++        )
++
++    def test_ec2credential_ban_can_be_disabled(self):
++        self.config_fixture.config(
++            group='auth', ban_ec2credential_tokens=False
++        )
++        signer = ec2_utils.Ec2Signer(self.cred_blob['secret'])
++        timestamp = utils.isotime(timeutils.utcnow())
++        credentials = {
++            'access': self.cred_blob['access'],
++            'secret': self.cred_blob['secret'],
++            'host': 'localhost',
++            'verb': 'GET',
++            'path': '/',
++            'params': {
++                'SignatureVersion': '2',
++                'Action': 'Test',
++                'Timestamp': timestamp,
++            },
++        }
++        credentials['signature'] = signer.generate(credentials)
++        PROVIDERS.assignment_api.create_system_grant_for_user(
++            self.user_id, self.role_id
++        )
++        token = self.get_system_scoped_token()
++        resp = self.post(
++            '/ec2tokens',
++            body={'credentials': credentials},
++            expected_status=http.client.OK,
++            token=token,
++        )
++        ec2_token = resp.headers['X-Subject-Token']
++
++        # With the ban disabled, the EC2 token is accepted like any other
++        # token by the auth middleware (still subject to normal RBAC).
++        self.get(
++            f"/users/{self.user_id}",
++            token=ec2_token,
++            expected_status=http.client.OK,
++        )
+diff --git a/releasenotes/notes/ban-ec2credential-tokens-backport-9f3c7a1b2d4e5f6a.yaml b/releasenotes/notes/ban-ec2credential-tokens-backport-9f3c7a1b2d4e5f6a.yaml
+new file mode 100644
+index 000000000..b17d07ec7
+--- /dev/null
++++ b/releasenotes/notes/ban-ec2credential-tokens-backport-9f3c7a1b2d4e5f6a.yaml
+@@ -0,0 +1,16 @@
++---
++security:
++  - |
++    Tokens issued via EC2 credential authentication (``ec2credential``)
++    are now rejected by the auth middleware for every keystone API
++    operation except validating the token, which Swift's S3 protocol
++    support relies on. This closes off EC2-derived tokens from being
++    used as a general-purpose bearer credential against the rest of the
++    keystone API. Backported from a change already on master.
++upgrade:
++  - |
++    New config option ``[auth] ban_ec2credential_tokens``, default
++    ``True``. Deployments with an existing, undocumented dependency on
++    using EC2-derived tokens directly against the keystone API (beyond
++    token validation) can set this to ``False`` to restore the previous
++    behavior.
+-- 
+2.47.3
+


### PR DESCRIPTION
Ban ec2credential tokens from Keystone API

Upstream review: https://review.opendev.org/c/openstack/keystone/+/1002454