### PR TITLE
templates: fail build on pip check errors

### DIFF
--- a/templates/2024.2/template-overrides.mako
+++ b/templates/2024.2/template-overrides.mako
@@ -108,7 +108,8 @@ RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && apt-get remove -y build-essential ${"\\"}
     && apt-get autoremove -y ${"\\"}
-    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi
+    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi ${"\\"}
+    && if [ -e /var/lib/kolla/venv/bin/pip3 ]; then /var/lib/kolla/venv/bin/pip3 check; fi
 {% endblock %}
 
 {% block labels %}

--- a/templates/2025.1/template-overrides.mako
+++ b/templates/2025.1/template-overrides.mako
@@ -106,7 +106,8 @@ RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && apt-get remove -y build-essential ${"\\"}
     && apt-get autoremove -y ${"\\"}
-    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi
+    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi ${"\\"}
+    && if [ -e /var/lib/kolla/venv/bin/pip3 ]; then /var/lib/kolla/venv/bin/pip3 check; fi
 {% endblock %}
 
 {% block labels %}

--- a/templates/2025.2/template-overrides.mako
+++ b/templates/2025.2/template-overrides.mako
@@ -106,7 +106,8 @@ RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && apt-get remove -y build-essential ${"\\"}
     && apt-get autoremove -y ${"\\"}
-    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi
+    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi ${"\\"}
+    && if [ -e /var/lib/kolla/venv/bin/pip3 ]; then /var/lib/kolla/venv/bin/pip3 check; fi
 {% endblock %}
 
 {% block labels %}

--- a/templates/2026.1/template-overrides.mako
+++ b/templates/2026.1/template-overrides.mako
@@ -113,7 +113,8 @@ RUN rm -rf /usr/share/doc/* ${"\\"}
     && rm -rf /usr/share/man/* ${"\\"}
     && apt-get remove -y build-essential ${"\\"}
     && apt-get autoremove -y ${"\\"}
-    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi
+    && if [ -e /var/lib/kolla/venv/bin/python3 ]; then /var/lib/kolla/venv/bin/pip3 install --no-cache-dir pyclean==3.0.0; /var/lib/kolla/venv/bin/pyclean /var/lib/kolla/venv; /var/lib/kolla/venv/bin/pyclean /usr; /var/lib/kolla/venv/bin/pip3 uninstall -y pyclean; fi ${"\\"}
+    && if [ -e /var/lib/kolla/venv/bin/pip3 ]; then /var/lib/kolla/venv/bin/pip3 check; fi
 {% endblock %}
 
 {% block labels %}


### PR DESCRIPTION
## Where this is

`templates/<release>/template-overrides.mako` is this repo's kolla
template-override source: `scripts/001-prepare.sh` renders it into
`template-overrides.j2`, which `scripts/004-build.sh` hands to `kolla-build`
via `--template-override`. `{% block footer %}` fills kolla's global footer
extension point, so the `RUN` it contains is the **last step of every image**.

That block already ends with a venv-guarded step (the `pyclean` pass). This
change appends a second guarded step to the same `RUN`.

## What it does

```
&& if [ -e /var/lib/kolla/venv/bin/pip3 ]; then /var/lib/kolla/venv/bin/pip3 check; fi
```

- No kolla venv → the condition is false, the `if` returns 0, build proceeds.
  That matters: 150 of the 430 published images checked below have no venv.
- Venv present, consistent → `pip check` exits 0, build proceeds.
- Venv present, inconsistent → `pip check` exits 1 as the `RUN`'s final
  command, and the build fails.

## Why

pip resolves only the packages named in a single invocation, not the
environment it is installing into. A kolla image is inherently multi-`RUN`, so
a later layer can upgrade a package an earlier layer pinned and leave the venv
internally inconsistent. pip *reports* that, but a conflict report is not an
exit code — so the image builds and ships.

That is precisely how the keystone image broke last night. An unconstrained
plugin install pulled cryptography 43.0.3 → 50.0.1 over the constrained
version; pip printed

```
pyopenssl 24.2.1 requires cryptography<44,>=41.0.5, but you have
cryptography 50.0.1 which is incompatible.
```

and the build passed anyway. Every keystone entry point then died at import
(`AttributeError: module 'lib' has no attribute 'GEN_EMAIL'`), keystone never
bootstrapped, and the testbed `current` and `next` lanes timed out at 4h31m.

Constraining that one install closes that one mechanism:

- osism/container-images-kolla#781

It does nothing about the next package that does the same thing in a later
layer. This gate is the general guard.

## Evidence

Checked against every published leaf image of four release lines — **430
images**:

| | count |
|---|---|
| venv present, `pip check` clean | 278 |
| no venv (guard skips) | 150 |
| conflict | 2 |

The two conflicts:

| image | finding |
|---|---|
| `2025.1 keystone` | the #781 bug, since fixed |
| `2024.1 nova-compute` | `pygobject 3.42.1 requires pycairo, which is not installed` |

The second is **pre-existing and unrelated to pip**. `python3-gi` is installed
by *apt* in nova-compute as a dependency of `python3-guestfs` on 2024.1's
**jammy** base; the Ubuntu package declares `pycairo` in its Python metadata
while Debian ships that as `python3-cairo`, which is not pulled in. It is a
packaging metadata mismatch that has never broken anything — but `pip check`
cannot tell it apart from a real conflict. `nova-compute` is clean on 2024.2,
2025.1 and 2025.2, which all build on noble.

## Scope, and why it is not all six templates

Applied to **2024.2, 2025.1, 2025.2, 2026.1**. Left off:

- **2024.1** — would fail on the pygobject finding above. The release is
  `unmaintained-2024.1`, so pulling in `python3-cairo` purely to satisfy
  metadata did not seem worth it. Easy to revisit if the line is revived.
- **2023.2** — has no build or push job, so the gate could not be verified
  there and would protect nothing.

**2026.1 is included unverified**: its images are not published yet, so it was
not part of the sweep. Included on the grounds that it shares the noble base
with the three verified lines — flagging it rather than implying coverage.

If maintainers prefer uniform coverage, the alternative is to add
`python3-cairo` to 2024.1's nova-compute and gate all six. That is a real
change to a retiring release's package list, so I did not make it unilaterally.

## Verification

- All six templates parse under mako, and 2025.1 **renders** the intended
  Dockerfile fragment with correct `\` continuations (parsing alone would not
  catch a bad escape).
- Guard exit semantics tested directly: `0` with no venv, `0` on a clean
  check, `1` on a failing one.
- `osism-zuul-lint` clean.

## Limits

- `pip check` reads **declared metadata** only. A break where requirements are
  satisfied but a runtime API moved underneath still passes — this would not
  have caught, say, an API-incompatible minor bump.
- It catches cross-invocation drift, not conflicts within a single resolve;
  pip already rejects those.
- It is release-line scoped, not per-image, so a benign apt/pip metadata
  mismatch anywhere in a line blocks that whole line — as 2024.1 shows.

## Reproducing the check

Any published image can be spot-checked without building anything:

```
podman run --rm --entrypoint="" \
  registry.osism.tech/kolla/<image>:<release> \
  /var/lib/kolla/venv/bin/pip check
```

The sweep above is that command over every leaf image of a release, taking
`No broken requirements found` / exit 0 as a pass, and skipping images where
`/var/lib/kolla/venv/bin/pip` does not exist. Layer sharing keeps it cheap —
a whole release line is about 5 GB of unique layers rather than the ~39 GB the
per-image sizes suggest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
